### PR TITLE
Migrate hardcoded `app:*` values to environment variables

### DIFF
--- a/src/_index.yaml
+++ b/src/_index.yaml
@@ -2,6 +2,60 @@ version: "1.0"
 namespace: wippy.session
 
 entries:
+  # Requirements
+  - name: __requirement-target_api_router
+    kind: ns.requirement
+    meta:
+      description: "Application API router ID"
+    targets:
+      - entry: target_api_router
+        path: ".default"
+
+  - name: __requirement-target_processes_host
+    kind: ns.requirement
+    meta:
+      description: "Application processes host ID"
+    targets:
+      - entry: target_processes_host
+        path: ".default"
+
+  - name: __requirement-target_db
+    kind: ns.requirement
+    meta:
+      description: "Application database ID"
+    targets:
+      - entry: target_db
+        path: ".default"
+
+  # Environment Storage
+  - name: envs
+    kind: env.storage.os
+    meta:
+      type: envstorage
+      comment: OS storage for environment variables
+
+  # Environment Variables
+  - name: target_api_router
+    kind: env.variable
+    meta:
+      type: config_key
+      comment: API router resource identifier
+    storage: wippy.session:envs
+
+  - name: target_processes_host
+    kind: env.variable
+    meta:
+      type: config_key
+      comment: Processes host resource identifier
+    storage: wippy.session:envs
+
+  - name: target_db
+    kind: env.variable
+    meta:
+      type: config_key
+      comment: Database resource identifier
+    storage: wippy.session:envs
+
   # wippy.session:start_tokens
   - name: start_tokens
     kind: library.lua

--- a/src/_index.yaml
+++ b/src/_index.yaml
@@ -27,6 +27,42 @@ entries:
       - entry: target_db
         path: ".default"
 
+  # Dependencies
+  - name: __dependency.wippy.llm
+    kind: "ns.dependency"
+    meta:
+      description: "LLM component"
+    component: "wippy/llm"
+    version: ">=v0.0.12"
+
+  - name: __dependency.wippy.migration
+    kind: "ns.dependency"
+    meta:
+      description: "Migration component"
+    component: "wippy/migration"
+    version: ">=v0.0.10"
+
+  - name: __dependency.wippy.actor
+    kind: "ns.dependency"
+    meta:
+      description: "Actor component"
+    component: "wippy/actor"
+    version: ">=v0.0.10"
+
+  - name: __dependency.wippy.agent
+    kind: "ns.dependency"
+    meta:
+      description: "Agent component"
+    component: "wippy/agent"
+    version: ">=v0.0.10"
+
+  - name: __dependency.wippy.test
+    kind: "ns.dependency"
+    meta:
+      description: "Testing component"
+    component: "wippy/test"
+    version: ">=v0.0.8"
+
   # Environment Storage
   - name: envs
     kind: env.storage.os
@@ -71,7 +107,7 @@ entries:
       - crypto
       - base64
       - json
-    
+
   # wippy.session:start_tokens_test
   - name: start_tokens_test
     kind: function.lua
@@ -99,4 +135,3 @@ entries:
       start_tokens: wippy.session:start_tokens
       test: wippy.test:test
     method: run_tests
-    

--- a/src/api/_index.yaml
+++ b/src/api/_index.yaml
@@ -2,6 +2,33 @@ version: "1.0"
 namespace: wippy.session.api
 
 entries:
+  # Requirements
+  - name: __requirement-target_api_router
+    kind: ns.requirement
+    meta:
+      description: "Application API router ID for HTTP endpoints"
+    targets:
+      - entry: get_artifact
+        path: ".meta.router"
+      - entry: get_artifact.endpoint
+        path: ".meta.router"
+      - entry: get_artifact_content
+        path: ".meta.router"
+      - entry: get_artifact_content.endpoint
+        path: ".meta.router"
+      - entry: get_session
+        path: ".meta.router"
+      - entry: get_session.endpoint
+        path: ".meta.router"
+      - entry: list_sessions
+        path: ".meta.router"
+      - entry: list_sessions.endpoint
+        path: ".meta.router"
+      - entry: session_messages
+        path: ".meta.router"
+      - entry: session_messages.endpoint
+        path: ".meta.router"
+
   # wippy.session.api:get_artifact
   - name: get_artifact
     kind: function.lua
@@ -10,7 +37,6 @@ entries:
       depends_on:
         - ns:app
         - ns:wippy.session.persist
-      router: app:api
     source: file://get_artifact.lua
     modules:
       - http
@@ -30,7 +56,6 @@ entries:
       comment: Endpoint that returns metadata for an artifact
       depends_on:
         - ns:app
-      router: app:api
     method: GET
     func: get_artifact
     path: /artifact/{id}
@@ -43,7 +68,6 @@ entries:
       depends_on:
         - ns:app
         - ns:wippy.session.persist
-      router: app:api
     source: file://get_artifact_content.lua
     modules:
       - http
@@ -64,7 +88,6 @@ entries:
       comment: Endpoint that returns content for an artifact
       depends_on:
         - ns:app
-      router: app:api
     method: GET
     func: get_artifact_content
     path: /artifact/{id}/content
@@ -79,7 +102,6 @@ entries:
         - app:api
         - ns:wippy.session
         - ns:wippy.session.persist
-      router: app:api
     source: file://get_session.lua
     modules:
       - http
@@ -101,7 +123,6 @@ entries:
         - app:api
         - ns:wippy.session
         - ns:wippy.session.persist
-      router: app:api
     method: GET
     func: get_session
     path: /sessions/get
@@ -116,7 +137,6 @@ entries:
         - app:api
         - ns:wippy.session
         - ns:wippy.session.persist
-      router: app:api
     source: file://list_sessions.lua
     modules:
       - http
@@ -137,7 +157,6 @@ entries:
         - app:api
         - ns:wippy.session
         - ns:wippy.session.persist
-      router: app:api
     method: GET
     func: list_sessions
     path: /sessions
@@ -152,7 +171,6 @@ entries:
         - app:api
         - ns:wippy.session
         - ns:wippy.session.persist
-      router: app:api
     source: file://session_messages.lua
     modules:
       - http
@@ -175,7 +193,6 @@ entries:
         - app:api
         - ns:wippy.session
         - ns:wippy.session.persist
-      router: app:api
     method: GET
     func: session_messages
     path: /sessions/messages

--- a/src/migration/_index.yaml
+++ b/src/migration/_index.yaml
@@ -2,6 +2,25 @@ version: "1.0"
 namespace: wippy.session.migration
 
 entries:
+  # Requirements
+  - name: __requirement-target_db
+    kind: ns.requirement
+    meta:
+      description: "Application database ID for migrations"
+    targets:
+      - entry: 01_create_contexts_table
+        path: ".meta.target_db"
+      - entry: 02_create_sessions_table
+        path: ".meta.target_db"
+      - entry: 03_create_session_contexts_table
+        path: ".meta.target_db"
+      - entry: 04_create_messages_table
+        path: ".meta.target_db"
+      - entry: 05_create_artifacts_table
+        path: ".meta.target_db"
+      - entry: 06_add_user_id_to_artifacts_table
+        path: ".meta.target_db"
+
   # wippy.session.migration:01_create_contexts_table
   - name: 01_create_contexts_table
     kind: function.lua
@@ -12,7 +31,6 @@ entries:
       description: Create contexts table with indexes
       depends_on:
         - ns:wippy.migration
-      target_db: app:db
       timestamp: "2025-03-16T10:00:00Z"
     source: file://01_create_contexts_table.lua
     imports:
@@ -29,7 +47,6 @@ entries:
       description: Create sessions table with indexes
       depends_on:
         - ns:wippy.migration
-      target_db: app:db
       timestamp: "2025-03-16T10:05:00Z"
     source: file://02_create_sessions_table.lua
     imports:
@@ -46,7 +63,6 @@ entries:
       description: Create session_contexts table
       depends_on:
         - ns:wippy.migration
-      target_db: app:db
       timestamp: "2025-03-16T10:10:00Z"
     source: file://03_create_session_contexts_table.lua
     imports:
@@ -63,7 +79,6 @@ entries:
       description: Create messages table with indexes
       depends_on:
         - ns:wippy.migration
-      target_db: app:db
       timestamp: "2025-03-16T10:20:00Z"
     source: file://04_create_messages_table.lua
     imports:
@@ -80,7 +95,6 @@ entries:
       description: Create artifacts table with indexes
       depends_on:
         - ns:wippy.migration
-      target_db: app:db
       timestamp: "2025-03-16T10:25:00Z"
     source: file://05_create_artifacts_table.lua
     imports:
@@ -97,7 +111,6 @@ entries:
       description: Add user_id column to artifacts table
       depends_on:
         - ns:wippy.migration
-      target_db: app:db
       timestamp: "2025-05-28T08:12:00Z"
     source: file://06_add_user_id_to_artifacts_table.lua
     imports:

--- a/src/persist/artifact_repo.lua
+++ b/src/persist/artifact_repo.lua
@@ -2,9 +2,10 @@ local sql = require("sql")
 local json = require("json")
 local time = require("time")
 local security = require("security")
+local env = require("env")
 
--- Hardcoded database resource name
-local DB_RESOURCE = "app:db"
+-- Constants
+local DB_RESOURCE, _ = env.get("wippy.session:target_db")
 
 local artifact_repo = {}
 

--- a/src/persist/artifact_repo_test.lua
+++ b/src/persist/artifact_repo_test.lua
@@ -7,6 +7,7 @@ local session_repo = require("session_repo")
 local context_repo = require("context_repo")
 local time = require("time")
 local security = require("security")
+local env = require("env")
 
 local function define_tests()
     describe("Artifact Repository", function()
@@ -55,7 +56,8 @@ local function define_tests()
         -- Clean up test data after all tests
         after_all(function()
             -- Get a database connection for cleanup
-            local db, err = sql.get("app:db")
+            local db_resource, _ = env.get("wippy.session:target_db")
+            local db, err = sql.get(db_resource)
             if err then
                 error("Failed to connect to database: " .. err)
             end

--- a/src/persist/context_repo.lua
+++ b/src/persist/context_repo.lua
@@ -1,8 +1,9 @@
 local sql = require("sql")
 local time = require("time")
+local env = require("env")
 
--- Hardcoded database resource name
-local DB_RESOURCE = "app:db"
+-- Constants
+local DB_RESOURCE, _ = env.get("wippy.session:target_db")
 
 local context_repo = {}
 

--- a/src/persist/context_repo_test.lua
+++ b/src/persist/context_repo_test.lua
@@ -3,6 +3,7 @@ local test = require("test")
 local uuid = require("uuid")
 local context_repo = require("context_repo")
 local time = require("time")
+local env = require("env")
 
 local function define_tests()
     describe("Context Repository", function()
@@ -15,7 +16,8 @@ local function define_tests()
         -- Clean up test data after all tests
         after_all(function()
             -- Get a database connection for cleanup
-            local db, err = sql.get("app:db")
+            local db_resource, _ = env.get("wippy.session:target_db")
+            local db, err = sql.get(db_resource)
             if err then
                 error("Failed to connect to database: " .. err)
             end

--- a/src/persist/message_repo.lua
+++ b/src/persist/message_repo.lua
@@ -1,9 +1,10 @@
 local sql = require("sql")
 local json = require("json")
 local time = require("time")
+local env = require("env")
 
--- Hardcoded database resource name
-local DB_RESOURCE = "app:db"
+-- Constants
+local DB_RESOURCE, _ = env.get("wippy.session:target_db")
 
 local message_repo = {}
 

--- a/src/persist/message_repo_test.lua
+++ b/src/persist/message_repo_test.lua
@@ -7,6 +7,7 @@ local session_repo = require("session_repo")
 local context_repo = require("context_repo")
 local time = require("time")
 local security = require("security")
+local env = require("env")
 
 local function define_tests()
     describe("Message Repository", function()
@@ -55,7 +56,8 @@ local function define_tests()
         -- Clean up test data after all tests
         after_all(function()
             -- Get a database connection for cleanup
-            local db, err = sql.get("app:db")
+            local db_resource, _ = env.get("wippy.session:target_db")
+            local db, err = sql.get(db_resource)
             if err then
                 error("Failed to connect to database: " .. err)
             end

--- a/src/persist/session_contexts_repo.lua
+++ b/src/persist/session_contexts_repo.lua
@@ -1,9 +1,10 @@
 local sql = require("sql")
 local json = require("json")
 local time = require("time")
+local env = require("env")
 
--- Hardcoded database resource name
-local DB_RESOURCE = "app:db"
+-- Constants
+local DB_RESOURCE, _ = env.get("wippy.session:target_db")
 
 local session_contexts_repo = {}
 

--- a/src/persist/session_contexts_repo_test.lua
+++ b/src/persist/session_contexts_repo_test.lua
@@ -6,6 +6,7 @@ local session_repo = require("session_repo")
 local context_repo = require("context_repo")
 local time = require("time")
 local security = require("security")
+local env = require("env")
 
 local function define_tests()
     describe("Session Contexts Repository", function()
@@ -54,7 +55,8 @@ local function define_tests()
         -- Clean up test data after all tests
         after_all(function()
             -- Get a database connection for cleanup
-            local db, err = sql.get("app:db")
+            local db_resource, _ = env.get("wippy.session:target_db")
+            local db, err = sql.get(db_resource)
             if err then
                 error("Failed to connect to database: " .. err)
             end

--- a/src/persist/session_repo.lua
+++ b/src/persist/session_repo.lua
@@ -1,9 +1,10 @@
 local sql = require("sql")
 local json = require("json")
 local time = require("time")
+local env = require("env")
 
--- Hardcoded database resource name
-local DB_RESOURCE = "app:db"
+-- Constants
+local DB_RESOURCE, _ = env.get("wippy.session:target_db")
 
 local session_repo = {}
 

--- a/src/persist/session_repo_test.lua
+++ b/src/persist/session_repo_test.lua
@@ -5,6 +5,7 @@ local session_repo = require("session_repo")
 local context_repo = require("context_repo")
 local time = require("time")
 local security = require("security")
+local env = require("env")
 
 local function define_tests()
     describe("Session Repository", function()
@@ -48,7 +49,8 @@ local function define_tests()
         -- Clean up test data after all tests
         after_all(function()
             -- Get a database connection for cleanup
-            local db, err = sql.get("app:db")
+            local db_resource, _ = env.get("wippy.session:target_db")
+            local db, err = sql.get(db_resource)
             if err then
                 error("Failed to connect to database: " .. err)
             end

--- a/src/process/_index.yaml
+++ b/src/process/_index.yaml
@@ -2,6 +2,15 @@ version: "1.0"
 namespace: wippy.session.process
 
 entries:
+  # Requirements
+  - name: __requirement-target_processes_host
+    kind: ns.requirement
+    meta:
+      description: "Application processes host ID for process services"
+    targets:
+      - entry: session
+        path: ".meta.default_host"
+
   # wippy.session.process:consts
   - name: consts
     kind: library.lua
@@ -106,7 +115,6 @@ entries:
         - ns:wippy.session.persist
         - ns:wippy.llm
         - ns:wippy.agent.gen1
-      default_host: app:processes
     source: file://session.lua
     modules:
       - time


### PR DESCRIPTION
## What was changed

Replace all hardcoded `app:*` configuration values with configurable
environment variables following Wippy's dependency injection system.

Changes:
- Add environment storage and variables for target_db, target_api_router, 
target_processes_host
- Add requirements to inject values into module configurations
- Update all repository files to use env.get("wippy.session:target_db")
- Update test files to resolve database connections via environment
- Remove hardcoded router, target_db, and default_host values from YAML configs
- Maintain dependency references (depends_on) unchanged per guidelines
- Added dependency entries

This makes the module more flexible, testable, and deployment-friendly
by allowing external configuration of database, API router, and process 
host resources.
