### PR TITLE
Fix the order of operations with the session context

### DIFF
--- a/src/process/tool_handler.lua
+++ b/src/process/tool_handler.lua
@@ -335,6 +335,14 @@ function tool_handler.process_control_context(controller, context)
     if context.session then
         local session_context_success = true
 
+        -- Delete session context values
+        if context.session.delete and type(context.session.delete) == "table" then
+            for _, key in ipairs(context.session.delete) do
+                local delete_success, _ = ctx_manager:delete_context(key)
+                if not delete_success then session_context_success = false end
+            end
+        end
+
         -- Set session context values
         if context.session.set and type(context.session.set) == "table" then
             for key, value in pairs(context.session.set) do
@@ -342,14 +350,6 @@ function tool_handler.process_control_context(controller, context)
                 if not set_success then
                     session_context_success = false
                 end
-            end
-        end
-
-        -- Delete session context values
-        if context.session.delete and type(context.session.delete) == "table" then
-            for _, key in ipairs(context.session.delete) do
-                local delete_success, _ = ctx_manager:delete_context(key)
-                if not delete_success then session_context_success = false end
             end
         end
 


### PR DESCRIPTION
## What was changed

In the current implementation, session context elements are set first and then deleted. If you need to delete and set a value with the same key (to replace the old value), this will not work. I have fixed the order of operations so that records are deleted first and then new ones are added.

## Checklist

- Closes #
- Tested
    - [ ] Tested manually
    - [ ] Unit tests added
