### PR TITLE
Add the ability to store llm provider metadata in session message

### DIFF
--- a/src/persist/message_repo.lua
+++ b/src/persist/message_repo.lua
@@ -178,6 +178,18 @@ function message_repo.update_metadata(message_id, metadata)
         return nil, "Metadata is required"
     end
 
+    local message, err = message_repo.get(message_id)
+    if not message or err then
+        return nil, "Message not found"
+    end
+
+    if type(message.metadata) == "table" and type(metadata) == "table" then
+        for k, v in pairs(metadata) do
+            message.metadata[k] = v
+        end
+        metadata = message.metadata
+    end
+
     -- Convert metadata to JSON if it's a table
     local metadata_json = nil
     if type(metadata) == "table" then

--- a/src/process/message_handlers.lua
+++ b/src/process/message_handlers.lua
@@ -219,12 +219,16 @@ function message_handlers.process_tools(ctx, op)
                 send_upstream = false
             end
 
-            local message_id, err = ctx.writer:add_message(message_type, json.encode(tool_call.args), {
+            local msg_metadata = {
                 call_id = call_id,
                 function_name = tool_call.name,
                 registry_id = tool_call.registry_id,
                 status = consts.FUNC_STATUS.PENDING
-            })
+            }
+            if tool_call.provider_metadata then
+                msg_metadata.provider_metadata = tool_call.provider_metadata
+            end
+            local message_id, err = ctx.writer:add_message(message_type, json.encode(tool_call.args), msg_metadata)
 
             if not err then
                 tool_call.message_id = message_id

--- a/src/prompt_builder.lua
+++ b/src/prompt_builder.lua
@@ -87,7 +87,11 @@ function prompt_builder.build(messages, contexts, session_meta, options)
                 end
 
                 local llm_call_id = metadata.call_id or msg.message_id
-                builder:add_function_call(metadata.function_name, args, llm_call_id)
+                local opts = nil
+                if metadata.provider_metadata then
+                    opts = { provider_metadata = metadata.provider_metadata }
+                end
+                builder:add_function_call(metadata.function_name, args, llm_call_id, opts)
 
                 if metadata.status == consts.FUNC_STATUS.PENDING then
                     builder:add_function_result(metadata.function_name, "incomplete", llm_call_id)


### PR DESCRIPTION
## What was changed

Added the ability to store additional metadata in the session message, such as thoughtSignature for Gemini models.