### PR TITLE
fix(artifacts): render standalone artifacts (emit type=artifact message)

### DIFF
--- a/src/process/control_handlers.lua
+++ b/src/process/control_handlers.lua
@@ -214,6 +214,23 @@ function control_handlers.control_artifacts(ctx, op)
             end
 
             if #created_artifacts > 0 then
+                -- ⚠️ DO NOT REVERT unless you know exactly what you are doing. ⚠️
+                -- Chat front-ends render a standalone artifact card from a message
+                -- with type='artifact' + metadata.artifact_id. Without the line
+                -- below, standalone artifacts (instructions=false) never render in
+                -- the chat thread — only the SYSTEM/artifact_created message was
+                -- emitted, which front-ends do not render.
+                --
+                -- Gate to STANDALONE only: inline artifacts (instructions=true) are
+                -- rendered via the <artifact id="…"/> tag the agent embeds in its
+                -- reply (see the instructions block above). Emitting an artifact
+                -- message here for the inline case too would render it TWICE.
+                if artifact_data.instructions == false then
+                    ctx.writer:add_message(consts.MSG_TYPE.ARTIFACT, artifact_data.title, {
+                        artifact_id = artifact_id
+                    })
+                end
+
                 ctx.writer:add_message(consts.MSG_TYPE.SYSTEM, "Artifact created: " .. artifact_data.title, {
                     system_action = consts.SYSTEM_ACTIONS.ARTIFACT_CREATED,
                     artifact_id = artifact_id


### PR DESCRIPTION
## Problem

`control_handlers.control_artifacts` persists the artifact (assigns a `uuid.v7()` id) but surfaced it to the client **only** as a `MSG_TYPE.SYSTEM` message (`system_action = artifact_created`) plus a session `artifact_added` update.

Chat front-ends (e.g. the gen-2-chat web host) render a standalone artifact card from a message with **`type = 'artifact'` + `metadata.artifact_id`**, and have no handler for a `system_action = 'artifact_created'` system message. As a result, **standalone artifacts (`instructions = false`, the default) never rendered** in the chat thread — only the tool-call badge showed.

## Fix

Emit a dedicated artifact message:

```lua
ctx.writer:add_message(consts.MSG_TYPE.ARTIFACT, artifact_data.title, { artifact_id = artifact_id })
```

…**gated to `instructions == false`**. Inline artifacts (`instructions = true`) are rendered via the `<artifact id="…"/>` tag the agent embeds in its reply (the instructions block above), so emitting an artifact message for the inline case too would render the same artifact **twice**. The gate makes the two paths mutually exclusive.

The existing SYSTEM/`artifact_created` message + `update_session({ artifact_added })` are kept (agent context / session signalling).

## Verification

Against the gen-2-chat host + app-template (OpenRouter-backed Sonnet): a standalone mermaid artifact now renders as a card in the chat; an inline-artifact request produces **no duplicate** (0 standalone cards).
