### PR TITLE
fix(api): sanitize error responses in HTTP handlers

### DIFF
--- a/src/api/_index.yaml
+++ b/src/api/_index.yaml
@@ -2,6 +2,15 @@ version: "1.0"
 namespace: wippy.session.api
 
 entries:
+  # wippy.session.api:api_error
+  - name: api_error
+    kind: library.lua
+    meta:
+      comment: API error helper
+    source: file://api_error.lua
+    modules:
+      - logger
+
   # wippy.session.api:delete_session
   - name: delete_session
     kind: function.lua
@@ -13,6 +22,7 @@ entries:
       - http
       - security
     imports:
+      api_error: wippy.session.api:api_error
       session_repo: wippy.session.persist:session_repo
     method: handler
     pool:
@@ -40,6 +50,7 @@ entries:
       - json
       - security
     imports:
+      api_error: wippy.session.api:api_error
       artifact_repo: wippy.session.persist:artifact_repo
       session_repo: wippy.session.persist:session_repo
     method: handler
@@ -68,6 +79,7 @@ entries:
       - json
       - security
     imports:
+      api_error: wippy.session.api:api_error
       artifact_repo: wippy.session.persist:artifact_repo
       renderer: wippy.views:renderer
       session_repo: wippy.session.persist:session_repo
@@ -96,6 +108,7 @@ entries:
       - http
       - security
     imports:
+      api_error: wippy.session.api:api_error
       message_repo: wippy.session.persist:message_repo
       session_repo: wippy.session.persist:session_repo
     method: handler
@@ -123,6 +136,7 @@ entries:
       - http
       - security
     imports:
+      api_error: wippy.session.api:api_error
       session_repo: wippy.session.persist:session_repo
     method: handler
     pool:
@@ -148,6 +162,7 @@ entries:
       - http
       - security
     imports:
+      api_error: wippy.session.api:api_error
       session_writer: wippy.session.persist:writer
     method: handler
 
@@ -173,6 +188,7 @@ entries:
       - security
       - time
     imports:
+      api_error: wippy.session.api:api_error
       message_repo: wippy.session.persist:message_repo
       session_repo: wippy.session.persist:session_repo
     method: handler

--- a/src/api/api_error.lua
+++ b/src/api/api_error.lua
@@ -1,0 +1,17 @@
+local log = require("logger"):named("wippy.session.api")
+
+local api_error = {}
+
+function api_error.fail(res, status, message, err)
+    if err ~= nil then
+        log:error(message, { error = tostring(err) })
+    end
+
+    res:set_status(status)
+    res:write_json({
+        success = false,
+        error = message
+    })
+end
+
+return api_error

--- a/src/api/delete_session.lua
+++ b/src/api/delete_session.lua
@@ -1,6 +1,7 @@
 local http = require("http")
 local security = require("security")
 local session_repo = require("session_repo")
+local api_error = require("api_error")
 
 type DeleteSessionResponse = {
     success: boolean,
@@ -52,11 +53,7 @@ local function handler()
                 error = "Session not found"
             })
         else
-            res:set_status(http.STATUS.INTERNAL_ERROR)
-            res:write_json({
-                success = false,
-                error = err
-            })
+            api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to retrieve session", err)
         end
         return
     end
@@ -74,11 +71,7 @@ local function handler()
     -- Delete the session
     local result, err = session_repo.delete(session_id)
     if err then
-        res:set_status(http.STATUS.INTERNAL_ERROR)
-        res:write_json({
-            success = false,
-            error = err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to delete session", err)
         return
     end
 

--- a/src/api/get_artifact.lua
+++ b/src/api/get_artifact.lua
@@ -3,6 +3,7 @@ local json = require("json")
 local artifact_repo = require("artifact_repo")
 local session_repo = require("session_repo")
 local security = require("security")
+local api_error = require("api_error")
 
 type ArtifactMetadataResponse = {
     uuid: string,
@@ -70,12 +71,8 @@ local function handler()
         end
 
         -- Handle other errors
-        res:set_status(http.STATUS.INTERNAL_ERROR)
         res:set_content_type(http.CONTENT.JSON)
-        res:write_json({
-            success = false,
-            error = "Failed to retrieve artifact: " .. err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to retrieve artifact", err)
         return
     end
 
@@ -83,12 +80,8 @@ local function handler()
     if artifact.session_id and artifact.session_id ~= "" then
         local session, session_err = session_repo.get(artifact.session_id)
         if session_err then
-            res:set_status(http.STATUS.INTERNAL_ERROR)
             res:set_content_type(http.CONTENT.JSON)
-            res:write_json({
-                success = false,
-                error = "Failed to verify artifact ownership: " .. session_err
-            })
+            api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to verify artifact ownership", session_err)
             return
         end
 

--- a/src/api/get_artifact_content.lua
+++ b/src/api/get_artifact_content.lua
@@ -4,6 +4,7 @@ local artifact_repo = require("artifact_repo")
 local session_repo = require("session_repo")
 local security = require("security")
 local renderer = require("renderer")
+local api_error = require("api_error")
 
 local function handler()
     -- Get response object
@@ -31,12 +32,8 @@ local function handler()
     -- Get artifact ID from URL path
     local artifact_id, err = req:param("id")
     if err then
-        res:set_status(http.STATUS.INTERNAL_ERROR)
         res:set_content_type(http.CONTENT.JSON)
-        res:write_json({
-            success = false,
-            error = "Error getting path parameter: " .. err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Error getting path parameter", err)
         return
     end
 
@@ -65,12 +62,8 @@ local function handler()
         end
 
         -- Handle other errors
-        res:set_status(http.STATUS.INTERNAL_ERROR)
         res:set_content_type(http.CONTENT.JSON)
-        res:write_json({
-            success = false,
-            error = "Failed to retrieve artifact metadata: " .. err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to retrieve artifact metadata", err)
         return
     end
 
@@ -78,12 +71,8 @@ local function handler()
     if artifact.session_id and artifact.session_id ~= "" then
         local session, session_err = session_repo.get(artifact.session_id)
         if session_err then
-            res:set_status(http.STATUS.INTERNAL_ERROR)
             res:set_content_type(http.CONTENT.JSON)
-            res:write_json({
-                success = false,
-                error = "Failed to verify artifact ownership: " .. session_err
-            })
+            api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to verify artifact ownership", session_err)
             return
         end
 
@@ -126,12 +115,8 @@ local function handler()
         -- Get the content (which contains our JSON parameters)
         local content_json, content_err = artifact_repo.get_content(artifact_id)
         if content_err then
-            res:set_status(http.STATUS.INTERNAL_ERROR)
             res:set_content_type(http.CONTENT.JSON)
-            res:write_json({
-                success = false,
-                error = "Failed to retrieve page parameters: " .. content_err
-            })
+            api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to retrieve page parameters", content_err)
             return
         end
 
@@ -140,12 +125,8 @@ local function handler()
         if content_json and content_json ~= "" then
             local decoded, json_err = json.decode(content_json :: string)
             if json_err then
-                res:set_status(http.STATUS.INTERNAL_ERROR)
                 res:set_content_type(http.CONTENT.JSON)
-                res:write_json({
-                    success = false,
-                    error = "Failed to parse parameters: " .. json_err
-                })
+                api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to parse parameters", json_err)
                 return
             end
             params = decoded
@@ -162,12 +143,8 @@ local function handler()
         local rendered_content, render_err = renderer.render(page_id, params, query)
 
         if render_err then
-            res:set_status(http.STATUS.INTERNAL_ERROR)
             res:set_content_type(http.CONTENT.JSON)
-            res:write_json({
-                success = false,
-                error = "Failed to render page reference: " .. render_err
-            })
+            api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to render page reference", render_err)
             return
         end
 
@@ -181,12 +158,8 @@ local function handler()
     -- For other artifact types, continue with normal content retrieval
     local content, content_err = artifact_repo.get_content(artifact_id)
     if content_err then
-        res:set_status(http.STATUS.INTERNAL_ERROR)
         res:set_content_type(http.CONTENT.JSON)
-        res:write_json({
-            success = false,
-            error = "Failed to retrieve artifact content: " .. content_err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to retrieve artifact content", content_err)
         return
     end
 

--- a/src/api/get_session.lua
+++ b/src/api/get_session.lua
@@ -2,6 +2,7 @@ local http = require("http")
 local security = require("security")
 local session_repo = require("session_repo")
 local message_repo = require("message_repo")
+local api_error = require("api_error")
 
 type GetSessionResponse = {
     success: boolean,
@@ -43,11 +44,7 @@ local function handler()
 
     local session, err = session_repo.get(session_id, user_id)
     if err then
-        res:set_status(http.STATUS.NOT_FOUND)
-        res:write_json({
-            success = false,
-            error = err
-        })
+        api_error.fail(res, http.STATUS.NOT_FOUND, "Session not found", err)
         return
     end
 

--- a/src/api/list_sessions.lua
+++ b/src/api/list_sessions.lua
@@ -1,6 +1,7 @@
 local http = require("http")
 local security = require("security")
 local session_repo = require("session_repo")
+local api_error = require("api_error")
 
 type ListSessionsResponse = {
     success: boolean,
@@ -40,21 +41,13 @@ local function handler()
 
     local total_count, err = session_repo.count_by_user(user_id)
     if err then
-        res:set_status(http.STATUS.INTERNAL_ERROR)
-        res:write_json({
-            success = false,
-            error = err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to count sessions", err)
         return
     end
 
     local sessions, err = session_repo.list_by_user(user_id, limit, offset)
     if err then
-        res:set_status(http.STATUS.INTERNAL_ERROR)
-        res:write_json({
-            success = false,
-            error = err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to list sessions", err)
         return
     end
 

--- a/src/api/rename_session.lua
+++ b/src/api/rename_session.lua
@@ -1,6 +1,7 @@
 local http = require("http")
 local security = require("security")
 local session_writer = require("session_writer")
+local api_error = require("api_error")
 
 type RenameSessionResponse = {
     success: boolean,
@@ -76,21 +77,13 @@ local function handler()
         elseif err:find("No security actor") then
             status = http.STATUS.UNAUTHORIZED
         end
-        res:set_status(status)
-        res:write_json({
-            success = false,
-            error = err
-        })
+        api_error.fail(res, status, "Failed to open session", err)
         return
     end
 
     local _, err = writer:update_title(title)
     if err then
-        res:set_status(http.STATUS.INTERNAL_ERROR)
-        res:write_json({
-            success = false,
-            error = err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to rename session", err)
         return
     end
 

--- a/src/api/session_messages.lua
+++ b/src/api/session_messages.lua
@@ -4,6 +4,7 @@ local session_repo = require("session_repo")
 local message_repo = require("message_repo")
 local time = require("time")
 local json = require("json")
+local api_error = require("api_error")
 
 type SessionMessagesResponse = {
     success: boolean,
@@ -54,11 +55,7 @@ local function handler()
     -- Verify session belongs to the authenticated user
     local session, err = session_repo.get(session_id, user_id)
     if err then
-        res:set_status(http.STATUS.NOT_FOUND)
-        res:write_json({
-            success = false,
-            error = err
-        })
+        api_error.fail(res, http.STATUS.NOT_FOUND, "Session not found", err)
         return
     end
 
@@ -86,11 +83,7 @@ local function handler()
     -- Get messages for this session with cursor-based pagination
     local result, err = message_repo.list_by_session(session_id, limit, cursor, direction)
     if err then
-        res:set_status(http.STATUS.INTERNAL_ERROR)
-        res:write_json({
-            success = false,
-            error = err
-        })
+        api_error.fail(res, http.STATUS.INTERNAL_ERROR, "Failed to retrieve messages", err)
         return
     end
 


### PR DESCRIPTION
## Why
HTTP handlers wrote raw upstream error strings into client responses, disclosing driver/schema/internal error details to external clients — the same information-disclosure class as the userspace login credential leak.

## What
A per-namespace `api_error` helper logs the raw error server-side via `logger` and returns only `{ success = false, error = <public message> }`. Every HTTP handler routes its error responses through it. HTTP status codes and other response fields are preserved; text (non-JSON) handlers log the error and write a static message.

## Testing
- HTTP-endpoint leak mapper (cross-references `http.endpoint` → handler source): **zero** raw error variables reach any client response field after the change. Remaining grep hits are all server-side `log:` tables, sanitizing helpers, or guarded client-safe domain messages.
- `luac -p` clean on all edited non-type-annotated files.
- Internal contract/process returns and server-side log lines were intentionally left unchanged (not client-facing).
