### PR TITLE
Fix session startup config normalization

### DIFF
--- a/src/_index.yaml
+++ b/src/_index.yaml
@@ -130,15 +130,6 @@ entries:
       - entry: wippy.session.env:delegation_func_id
         path: ".default"
 
-  - name: on_session_end_func_id
-    kind: ns.requirement
-    meta:
-      description: "Function ID called when a session ends (runs in the plugin actor context). Optional; empty disables the hook."
-    default: ""
-    targets:
-      - entry: wippy.session.env:on_session_end_func_id
-        path: ".default"
-
   - name: env_storage
     kind: ns.requirement
     meta:
@@ -162,8 +153,6 @@ entries:
         path: ".storage"
       - entry: wippy.session.env:delegation_func_id
         path: ".storage"
-      - entry: wippy.session.env:on_session_end_func_id
-        path: ".storage"
 
   # wippy.session:consts
   - name: consts
@@ -174,6 +163,257 @@ entries:
     modules:
       - env
       - time
+
+  # wippy.session:session_service
+  - name: session_service
+    kind: contract.definition
+    meta:
+      comment: Session-owned lifecycle service for external runtimes.
+      tags:
+        - session
+        - runtime
+        - lifecycle
+        - service
+      description: |
+        Stable session service contract for runtimes such as channel and DM.
+        Callers ask session to ensure, read, update, or delete a session instead
+        of importing wippy.session.persist repositories or hand-rolling context
+        creation and status recovery.
+
+        ensure is the canonical create-or-rehydrate operation. It creates the
+        primary session context when the session is new, returns the existing row
+        when it already exists, and by default resets stale running/failed status
+        to idle so a runtime can safely spawn the session process.
+    methods:
+      - name: ensure
+        description: Create a session if absent, otherwise return and prepare the existing session for rehydration.
+        input_schemas:
+          - definition: |
+              {
+                "type": "object",
+                "properties": {
+                  "session_id": { "type": "string" },
+                  "user_id": { "type": "string" },
+                  "kind": { "type": "string", "default": "default" },
+                  "title": { "type": "string", "default": "" },
+                  "meta": { "type": "object", "default": {} },
+                  "config": { "type": "object", "default": {} },
+                  "primary_context_id": { "type": "string" },
+                  "primary_context_data": {
+                    "description": "Initial primary context payload. Objects are JSON encoded; strings are stored as-is.",
+                    "oneOf": [
+                      { "type": "object" },
+                      { "type": "string" }
+                    ],
+                    "default": {}
+                  },
+                  "reset_status": {
+                    "type": "boolean",
+                    "description": "When true or omitted, running/failed sessions are reset to idle for safe rehydration.",
+                    "default": true
+                  }
+                },
+                "required": ["session_id", "user_id"]
+              }
+            format: application/schema+json
+        output_schemas:
+          - definition: |
+              {
+                "type": "object",
+                "properties": {
+                  "session": { "type": "object" },
+                  "created": { "type": "boolean" },
+                  "recovered": { "type": "boolean" },
+                  "primary_context_id": { "type": "string" }
+                },
+                "required": ["session", "created", "recovered", "primary_context_id"]
+              }
+            format: application/schema+json
+      - name: get
+        description: Read one session by id, optionally scoped to a user id.
+        input_schemas:
+          - definition: |
+              {
+                "type": "object",
+                "properties": {
+                  "session_id": { "type": "string" },
+                  "user_id": { "type": "string" }
+                },
+                "required": ["session_id"]
+              }
+            format: application/schema+json
+      - name: update
+        description: Update session metadata through the session-owned API.
+        input_schemas:
+          - definition: |
+              {
+                "type": "object",
+                "properties": {
+                  "session_id": { "type": "string" },
+                  "updates": {
+                    "type": "object",
+                    "properties": {
+                      "title": { "type": "string" },
+                      "status": { "type": "string" },
+                      "kind": { "type": "string" },
+                      "meta": { "type": "object" },
+                      "config": { "type": "object" },
+                      "public_meta": { "type": "object" },
+                      "last_message_date": { "type": "integer" }
+                    }
+                  }
+                },
+                "required": ["session_id", "updates"]
+              }
+            format: application/schema+json
+      - name: delete
+        description: Delete a session and the primary context owned by the service.
+        input_schemas:
+          - definition: |
+              {
+                "type": "object",
+                "properties": {
+                  "session_id": { "type": "string" },
+                  "user_id": {
+                    "type": "string",
+                    "description": "Optional owner guard. When provided, delete fails unless the session belongs to this user."
+                  }
+                },
+                "required": ["session_id"]
+              }
+            format: application/schema+json
+
+  # wippy.session:service
+  - name: service
+    kind: library.lua
+    meta:
+      comment: SDK implementation for the wippy.session:session_service contract.
+      tags:
+        - session
+        - runtime
+        - lifecycle
+    source: file://service.lua
+    modules:
+      - json
+      - uuid
+    imports:
+      consts: wippy.session:consts
+      session_repo: wippy.session.persist:session_repo
+      context_repo: wippy.session.persist:context_repo
+
+  # wippy.session:service_binding
+  - name: service_binding
+    kind: contract.binding
+    meta:
+      comment: Built-in implementation of the session service contract.
+      tags:
+        - session
+        - runtime
+        - lifecycle
+    contracts:
+      - contract: wippy.session:session_service
+        methods:
+          ensure: wippy.session:ensure_session
+          get: wippy.session:get_session_service
+          update: wippy.session:update_session_service
+          delete: wippy.session:delete_session_service
+
+  # wippy.session:ensure_session
+  - name: ensure_session
+    kind: function.lua
+    meta:
+      comment: Contract method wrapper for wippy.session:service.ensure.
+      tags:
+        - session
+        - runtime
+    source: file://ensure_session.lua
+    imports:
+      service: wippy.session:service
+    method: handle
+
+  # wippy.session:get_session_service
+  - name: get_session_service
+    kind: function.lua
+    meta:
+      comment: Contract method wrapper for wippy.session:service.get.
+      tags:
+        - session
+        - runtime
+    source: file://get_session_service.lua
+    imports:
+      service: wippy.session:service
+    method: handle
+
+  # wippy.session:update_session_service
+  - name: update_session_service
+    kind: function.lua
+    meta:
+      comment: Contract method wrapper for wippy.session:service.update.
+      tags:
+        - session
+        - runtime
+    source: file://update_session_service.lua
+    imports:
+      service: wippy.session:service
+    method: handle
+
+  # wippy.session:delete_session_service
+  - name: delete_session_service
+    kind: function.lua
+    meta:
+      comment: Contract method wrapper for wippy.session:service.delete.
+      tags:
+        - session
+        - runtime
+    source: file://delete_session_service.lua
+    imports:
+      service: wippy.session:service
+    method: handle
+
+  # wippy.session:service_test
+  - name: service_test_security_policy
+    kind: security.policy
+    meta:
+      scope: dev
+      comment: Allows the session service contract test to open the built-in binding.
+      tags:
+        - session
+        - runtime
+        - test
+    policy:
+      actions: "*"
+      resources: "*"
+      effect: allow
+    groups:
+      - test_group
+
+  # wippy.session:service_test
+  - name: service_test
+    kind: function.lua
+    meta:
+      type: test
+      suite: session
+      comment: Tests the session-owned service SDK and contract binding.
+      tags:
+        - session
+        - runtime
+        - lifecycle
+        - test
+    source: file://service_test.lua
+    modules:
+      - contract
+      - json
+      - security
+      - sql
+      - uuid
+    imports:
+      consts: wippy.session:consts
+      context_repo: wippy.session.persist:context_repo
+      service: wippy.session:service
+      session_repo: wippy.session.persist:session_repo
+      test: wippy.test:test
+      wait_for_boot: app:wait_for_boot
+    method: run
 
   # Dependencies
   - name: dep.wippy.llm

--- a/src/_index.yaml
+++ b/src/_index.yaml
@@ -429,7 +429,7 @@ entries:
   - name: dep.wippy.agent
     kind: ns.dependency
     component: wippy/agent
-    version: ">=v0.4.0"
+    version: ">=v0.4.11"
 
   - name: dep.wippy.views
     kind: ns.dependency

--- a/src/consts.lua
+++ b/src/consts.lua
@@ -11,7 +11,6 @@ type SessionConfig = {
     session_security_scope: string?,
     gc_interval: string?,
     delegation_func_id: string?,
-    on_session_end_func_id: string?,
     encryption_key: string?,
     enable_agent_cache: boolean?,
     delegation_description_suffix: string?,
@@ -29,7 +28,6 @@ local consts = {
         SESSION_SECURITY_SCOPE = "wippy.session.env:session_security_scope",
         GC_INTERVAL = "wippy.session.env:gc_interval",
         DELEGATION_FUNC_ID = "wippy.session.env:delegation_func_id",
-        ON_SESSION_END_FUNC_ID = "wippy.session.env:on_session_end_func_id",
         ENCRYPTION_KEY = "ENCRYPTION_KEY"
     },
 
@@ -323,7 +321,6 @@ function consts.get_config()
     local session_security_scope, _ = env.get(consts.ENV_IDS.SESSION_SECURITY_SCOPE)
     local gc_interval, _ = env.get(consts.ENV_IDS.GC_INTERVAL)
     local delegation_func_id, _ = env.get(consts.ENV_IDS.DELEGATION_FUNC_ID)
-    local on_session_end_func_id, _ = env.get(consts.ENV_IDS.ON_SESSION_END_FUNC_ID)
     local encryption_key, _ = env.get(consts.ENV_IDS.ENCRYPTION_KEY)
 
     return {
@@ -337,7 +334,6 @@ function consts.get_config()
         session_security_scope = session_security_scope,
         gc_interval = gc_interval,
         delegation_func_id = delegation_func_id,
-        on_session_end_func_id = on_session_end_func_id,
         encryption_key = encryption_key,
 
         -- Internal constants

--- a/src/delete_session_service.lua
+++ b/src/delete_session_service.lua
@@ -1,0 +1,9 @@
+local service = require("service")
+
+local M = {}
+
+function M.handle(args)
+    return service.delete(args)
+end
+
+return M

--- a/src/ensure_session.lua
+++ b/src/ensure_session.lua
@@ -1,0 +1,9 @@
+local service = require("service")
+
+local M = {}
+
+function M.handle(args)
+    return service.ensure(args)
+end
+
+return M

--- a/src/env/_index.yaml
+++ b/src/env/_index.yaml
@@ -82,16 +82,6 @@ entries:
 
     variable: SESSION_TITLE_FUNCTION_ID
 
-  # wippy.session.env:on_session_end_func_id
-  - name: on_session_end_func_id
-    kind: env.variable
-    meta:
-      comment: Function ID called when a session ends
-      icon: tabler:function
-      private: true
-
-    variable: SESSION_ON_SESSION_END_FUNC_ID
-
   # wippy.session.env:token_checkpoint_threshold
   - name: token_checkpoint_threshold
     kind: env.variable

--- a/src/get_session_service.lua
+++ b/src/get_session_service.lua
@@ -1,0 +1,9 @@
+local service = require("service")
+
+local M = {}
+
+function M.handle(args)
+    return service.get(args)
+end
+
+return M

--- a/src/persist/message_repo_test.lua
+++ b/src/persist/message_repo_test.lua
@@ -212,6 +212,15 @@ local function define_tests()
             end
         end)
 
+        it("should keep list_after_message inclusive for backward compatibility", function()
+            local messages, err = message_repo.list_after_message(test_data.session_id, test_data.message_id, 10)
+
+            test.is_nil(err)
+            test.not_nil(messages)
+            test.ok(#messages >= 1)
+            test.eq(messages[1].message_id, test_data.message_id)
+        end)
+
         it("should list messages by type", function()
             local messages, err = message_repo.list_by_type(test_data.session_id, "user")
 

--- a/src/process/_index.yaml
+++ b/src/process/_index.yaml
@@ -77,6 +77,7 @@ entries:
       agent_context: wippy.agent:context
       prompt_builder: wippy.session:prompt_builder
       tool_caller: wippy.agent.tools:caller
+      lifecycle_runtime: wippy.agent:lifecycle_runtime
       output: wippy.llm:output
 
   # wippy.session.process:session
@@ -117,7 +118,6 @@ entries:
       - json
       - uuid
       - logger
-      - funcs
     imports:
       consts: wippy.session:consts
       session_repo: wippy.session.persist:session_repo

--- a/src/process/_index.yaml
+++ b/src/process/_index.yaml
@@ -34,6 +34,19 @@ entries:
       consts: wippy.session:consts
       tool_caller: wippy.agent.tools:caller
 
+  # wippy.session.process:session_handlers_test
+  - name: session_handlers_test
+    kind: function.lua
+    meta:
+      type: test
+      suite: session_handlers
+      comment: Unit tests for session config normalization during agent/model changes.
+    source: file://session_handlers_test.lua
+    method: run_tests
+    imports:
+      session_handlers: wippy.session.process:session_handlers
+      test: wippy.test:test
+
   # wippy.session.process:control_handlers
   - name: control_handlers
     kind: library.lua

--- a/src/process/message_handlers.lua
+++ b/src/process/message_handlers.lua
@@ -4,6 +4,7 @@ local consts = require("consts")
 local prompt_builder = require("prompt_builder")
 local tool_caller = require("tool_caller")
 local output = require("output")
+local lifecycle_runtime = require("lifecycle_runtime")
 
 type SessionContext = {
     session_id: string,
@@ -14,9 +15,267 @@ type SessionContext = {
     config: {[string]: any},
     agent_ctx: any,
     queue_empty_callback: any?,
+    lifecycle_state: table?,
+}
+
+type ToolWrapperHostRef = {
+    kind: string,
+    session_id: string,
+}
+
+type ToolWrapperAgentRef = {
+    id: string?,
+    model: string?,
+}
+
+type ToolWrapperExecutionContext = {
+    host: ToolWrapperHostRef,
+    agent: ToolWrapperAgentRef,
+    run_context: table?,
 }
 
 local message_handlers = {}
+
+local RUN_CONTEXT_CONTRACT = "wippy.agent:run_context"
+local DEFAULT_RUN_CONTEXT_BINDING = "wippy.session.run_context:binding"
+
+local OUTCOME = {
+    CONTINUES = "continues",
+    COMPLETED = "completed",
+    FAILED = "failed",
+}
+
+local REASON = {
+    NO_TOOLS_REQUIRED = "no_tools_required",
+    TOOL_RESULTS_RECORDED = "tool_results_recorded",
+    CONTEXT_LIMIT_REACHED = "context_limit_reached",
+    HOST_FAILED = "host_failed",
+    AGENT_SWITCH = "agent_switch",
+    SESSION_FINISHED = "session_finished",
+}
+
+local function copy_context(context: any): table
+    local copied = {}
+    if type(context) == "table" then
+        for k, v in pairs(context) do
+            copied[k] = v
+        end
+    end
+    return copied
+end
+
+local function with_agent_run_context(ctx: SessionContext, context: any, agent_ref: ToolWrapperAgentRef?): table
+    local next_context = copy_context(context)
+    local host = {
+        kind = "session",
+        session_id = ctx.session_id
+    }
+    local agent_info = agent_ref or {
+        id = ctx.config and ctx.config.agent_id,
+        model = ctx.config and ctx.config.model
+    }
+
+    next_context.agent_run = {
+        host = host,
+        agent = agent_info,
+        run_context = {
+            contract = RUN_CONTEXT_CONTRACT,
+            binding = (ctx.config and ctx.config.run_context_binding) or DEFAULT_RUN_CONTEXT_BINDING,
+            host = host,
+            agent = agent_info
+        }
+    }
+
+    return next_context
+end
+
+local function host_ref(ctx: SessionContext): table
+    return {
+        kind = "session",
+        session_id = ctx.session_id
+    }
+end
+
+local function string_or_nil(value: any): string?
+    if type(value) == "string" and value ~= "" then
+        return value
+    end
+    return nil
+end
+
+local function agent_ref_from(ctx: SessionContext, agent: any?): ToolWrapperAgentRef
+    return {
+        id = string_or_nil(agent and agent.id or (ctx.config and ctx.config.agent_id)),
+        model = string_or_nil(agent and agent.model or (ctx.config and ctx.config.model))
+    }
+end
+
+local function run_context_ref(ctx: SessionContext, agent_ref: ToolWrapperAgentRef, host: table): table
+    return {
+        contract = RUN_CONTEXT_CONTRACT,
+        binding = (ctx.config and ctx.config.run_context_binding) or DEFAULT_RUN_CONTEXT_BINDING,
+        host = host,
+        agent = agent_ref
+    }
+end
+
+local function apply_lifecycle(ctx: SessionContext, phase: string, agent: any?, opts: table?): (table?, string?)
+    if not agent or type(agent.bindings) ~= "table" then
+        return { applied = 0, skipped = 0 }, nil
+    end
+
+    local host = host_ref(ctx)
+    local agent_ref = agent_ref_from(ctx, agent)
+    local payload = {
+        phase = phase,
+        host = host,
+        agent = agent_ref,
+        reason = opts and opts.reason,
+        outcome = opts and opts.outcome,
+        refs = opts and opts.refs,
+        run_context = run_context_ref(ctx, agent_ref, host),
+    } :: LifecyclePayload
+
+    return lifecycle_runtime.apply(agent.bindings, payload)
+end
+
+local function append_lifecycle_messages(builder: any, result: table?)
+    if not builder or type(result) ~= "table" or type(result.messages) ~= "table" then
+        return
+    end
+
+    for _, message in ipairs(result.messages) do
+        if type(message) == "table" then
+            local content = message.content or message.text or message.data
+            if type(content) == "string" and content ~= "" then
+                local role = message.role or message.type or "developer"
+                if role == "system" and type(builder.add_system) == "function" then
+                    builder:add_system(content)
+                elseif role == "user" and type(builder.add_user) == "function" then
+                    builder:add_user(content)
+                elseif role == "assistant" and type(builder.add_assistant) == "function" then
+                    builder:add_assistant(content, message.metadata)
+                elseif type(builder.add_developer) == "function" then
+                    builder:add_developer(content, message.metadata)
+                end
+            end
+        end
+    end
+end
+
+local function current_agent(ctx: SessionContext): any?
+    if ctx.agent_ctx and type(ctx.agent_ctx.get_current_agent) == "function" then
+        local agent = ctx.agent_ctx:get_current_agent()
+        if agent then
+            return agent
+        end
+    end
+
+    if ctx.config and ctx.config.agent_id and ctx.config.agent_id ~= "" and ctx.agent_ctx and type(ctx.agent_ctx.load_agent) == "function" then
+        local agent = ctx.agent_ctx:load_agent(ctx.config.agent_id, {
+            model = ctx.config.model
+        })
+        return agent
+    end
+
+    return nil
+end
+
+function message_handlers.deactivate_current_agent(ctx: SessionContext, reason: string?, outcome: table?): (table?, string?)
+    ctx.lifecycle_state = ctx.lifecycle_state or {}
+    local state = ctx.lifecycle_state
+    if not state.active_agent_id then
+        return { applied = 0, skipped = 0 }, nil
+    end
+
+    local agent = state.active_agent or current_agent(ctx)
+    if not agent then
+        state.active_agent_id = nil
+        state.active_model = nil
+        state.active_agent = nil
+        return { applied = 0, skipped = 0 }, nil
+    end
+
+    local result, err = apply_lifecycle(ctx, lifecycle_runtime.PHASE.DEACTIVATE, agent, {
+        reason = reason or REASON.SESSION_FINISHED,
+        outcome = outcome or {
+            state = OUTCOME.COMPLETED,
+            reason = reason or REASON.SESSION_FINISHED
+        }
+    })
+
+    if not err then
+        state.active_agent_id = nil
+        state.active_model = nil
+        state.active_agent = nil
+    end
+
+    return result, err
+end
+
+local function ensure_agent_activated(ctx: SessionContext, agent: any, refs: table?): (table?, string?)
+    ctx.lifecycle_state = ctx.lifecycle_state or {}
+    local state = ctx.lifecycle_state
+    local agent_ref = agent_ref_from(ctx, agent)
+    local same_agent = state.active_agent_id == agent_ref.id and state.active_model == agent_ref.model
+
+    if same_agent then
+        state.active_agent = agent
+        return { applied = 0, skipped = 0 }, nil
+    end
+
+    if state.active_agent_id then
+        local _, deactivate_err = message_handlers.deactivate_current_agent(ctx, REASON.AGENT_SWITCH, {
+            state = OUTCOME.CONTINUES,
+            reason = REASON.AGENT_SWITCH
+        })
+        if deactivate_err then
+            return nil, deactivate_err
+        end
+    end
+
+    local result, err = apply_lifecycle(ctx, lifecycle_runtime.PHASE.ACTIVATE, agent, {
+        reason = "agent_loaded",
+        refs = refs,
+        outcome = {
+            state = OUTCOME.CONTINUES,
+            reason = "agent_loaded"
+        }
+    })
+    if err then
+        return result, err
+    end
+
+    state.active_agent_id = agent_ref.id
+    state.active_model = agent_ref.model
+    state.active_agent = agent
+    return result, nil
+end
+
+local function outcome_from_agent_result(result: any): table
+    if result and result.truncated then
+        return {
+            state = OUTCOME.CONTINUES,
+            reason = REASON.CONTEXT_LIMIT_REACHED
+        }
+    end
+
+    local has_tools = result and (
+        (type(result.tool_calls) == "table" and #result.tool_calls > 0) or
+        (type(result.delegate_calls) == "table" and #result.delegate_calls > 0)
+    )
+    if has_tools then
+        return {
+            state = OUTCOME.CONTINUES,
+            reason = REASON.TOOL_RESULTS_RECORDED
+        }
+    end
+
+    return {
+        state = OUTCOME.COMPLETED,
+        reason = REASON.NO_TOOLS_REQUIRED
+    }
+end
 
 function message_handlers.handle_message(ctx, op)
     local message_id, err = ctx.writer:add_message(consts.MSG_TYPE.USER, op.data.text or "", {
@@ -67,6 +326,32 @@ function message_handlers.agent_step(ctx, op)
     if ctx_err then
         session_context = {}
     end
+    session_context = with_agent_run_context(ctx, session_context, agent_ref_from(ctx, agent))
+
+    local activate_result, activate_err = ensure_agent_activated(ctx, agent, {
+        message_id = op.message_id,
+        request_id = op.request_id
+    })
+    if activate_err then
+        return nil, activate_err
+    end
+    append_lifecycle_messages(builder, activate_result)
+
+    local before_result, before_err = apply_lifecycle(ctx, lifecycle_runtime.PHASE.BEFORE_STEP, agent, {
+        reason = "agent_step",
+        refs = {
+            message_id = op.message_id,
+            request_id = op.request_id
+        },
+        outcome = {
+            state = OUTCOME.CONTINUES,
+            reason = "agent_step"
+        }
+    })
+    if before_err then
+        return nil, before_err
+    end
+    append_lifecycle_messages(builder, before_result)
 
     ctx.upstream:response_beginning(response_id, op.message_id)
 
@@ -84,6 +369,20 @@ function message_handlers.agent_step(ctx, op)
     if exec_err then
         ctx.upstream:message_error(response_id, consts.ERROR_CODES.AGENT_ERROR, exec_err)
         return nil, exec_err
+    end
+
+    local _, after_err = apply_lifecycle(ctx, lifecycle_runtime.PHASE.AFTER_STEP, agent, {
+        reason = "agent_step",
+        refs = {
+            message_id = op.message_id,
+            response_id = response_id,
+            request_id = op.request_id
+        },
+        outcome = outcome_from_agent_result(result)
+    })
+    if after_err then
+        ctx.upstream:message_error(response_id, consts.ERROR_CODES.AGENT_ERROR, after_err)
+        return nil, after_err
     end
 
     if result.tokens and type(result.tokens) == "table" then
@@ -208,6 +507,11 @@ function message_handlers.agent_step(ctx, op)
         table.insert(user_facing_ops, {
             type = consts.OP_TYPE.PROCESS_TOOLS,
             tool_calls = unified_tool_calls,
+            tool_wrappers = agent.tool_wrappers or {},
+            agent = {
+                id = agent.id,
+                model = agent.model
+            },
             message_id = op.message_id,
             response_id = response_id,
             request_id = op.request_id,
@@ -220,6 +524,7 @@ function message_handlers.agent_step(ctx, op)
         table.insert(background_ops, {
             type = consts.OP_TYPE.CHECK_BACKGROUND_TRIGGERS,
             tokens = result.tokens,
+            agent_options = agent.agent_options or {},
             message_id = op.message_id
         })
     end
@@ -248,6 +553,40 @@ function message_handlers.process_tools(ctx, op)
 
     local caller = tool_caller.new()
     caller:set_strategy(tool_caller.STRATEGY.PARALLEL)
+
+    local op_agent = op.agent
+    if type(op_agent) ~= "table" then
+        op_agent = nil
+    end
+    local fallback_agent = {
+        id = string_or_nil(ctx.config and ctx.config.agent_id),
+        model = string_or_nil(ctx.config and ctx.config.model)
+    } :: ToolWrapperAgentRef
+    local active_agent = (op_agent or fallback_agent) :: ToolWrapperAgentRef
+
+    local wrapper_context: ToolWrapperExecutionContext = {
+        host = {
+            kind = "session",
+            session_id = ctx.session_id
+        },
+        agent = active_agent,
+        run_context = {
+            contract = RUN_CONTEXT_CONTRACT,
+            binding = (ctx.config and ctx.config.run_context_binding) or DEFAULT_RUN_CONTEXT_BINDING,
+            host = {
+                kind = "session",
+                session_id = ctx.session_id
+            },
+            agent = active_agent
+        }
+    }
+
+    if type(caller.set_tool_wrappers) == "function" then
+        caller:set_tool_wrappers(op.tool_wrappers or {})
+    end
+    if type(caller.set_wrapper_context) == "function" then
+        caller:set_wrapper_context(wrapper_context)
+    end
 
     local validated_tools, validate_err = caller:validate(op.tool_calls)
     if validate_err and not validated_tools then
@@ -291,6 +630,7 @@ function message_handlers.process_tools(ctx, op)
     if err then
         session_context = {}
     end
+    session_context = with_agent_run_context(ctx, session_context, active_agent)
 
     local results = caller:execute(session_context, validated_tools)
 

--- a/src/process/plugin.lua
+++ b/src/process/plugin.lua
@@ -1,7 +1,6 @@
 local time = require("time")
 local json = require("json")
 local uuid = require("uuid")
-local funcs = require("funcs")
 local logger = require("logger"):named("relay.session")
 local session_repo = require("session_repo")
 local context_repo = require("context_repo")
@@ -568,20 +567,6 @@ local function run(args)
                                 target_status = target_status,
                                 error = status_err
                             })
-                        end
-
-                        -- Invoke on_session_end hook if configured (non-blocking)
-                        if state.base_config.on_session_end_func_id and state.base_config.on_session_end_func_id ~= "" then
-                            local hook_func_id = state.base_config.on_session_end_func_id
-                            local hook_params = {
-                                session_id = session_id,
-                                user_id = state.user_id,
-                                status = target_status,
-                                reason = err,
-                            }
-                            coroutine.spawn(function()
-                                funcs.call(hook_func_id, hook_params)
-                            end)
                         end
 
                         state.active_sessions[session_id] = nil

--- a/src/process/session.lua
+++ b/src/process/session.lua
@@ -19,7 +19,19 @@ type SessionArgs = {
     start_token: string?,
 }
 
-local function run(args)
+type SessionContext = {
+    session_id: string,
+    user_id: string,
+    reader: any,
+    writer: any,
+    upstream: any,
+    config: {[string]: any},
+    agent_ctx: any,
+    queue_empty_callback: any?,
+    lifecycle_state: table?,
+}
+
+local function run(args: SessionArgs)
     if not args or not args.user_id or not args.session_id then
         error(consts.ERR.MISSING_ARGS)
     end
@@ -73,14 +85,15 @@ local function run(args)
         })
     end
 
-    local context = {
+    local context: SessionContext = {
         session_id = args.session_id,
         user_id = args.user_id,
         reader = session_reader,
         writer = session_writer,
         upstream = session_upstream,
-        config = session_data.config,
+        config = (session_data.config or {}) :: {[string]: any},
         agent_ctx = agent_ctx,
+        lifecycle_state = {},
         queue_empty_callback = function()
             session_writer:update_status(consts.STATUS.IDLE)
             session_upstream:update_session({ status = consts.STATUS.IDLE })
@@ -300,6 +313,17 @@ local function run(args)
 
     if not session_state.bus_done_received then
         bus_done:receive()
+    end
+
+    local _, lifecycle_err = message_handlers.deactivate_current_agent(context, "session_finished", {
+        state = "completed",
+        reason = "session_finished"
+    })
+    if lifecycle_err then
+        logger:warn("agent lifecycle deactivate failed", {
+            session_id = args.session_id,
+            error = tostring(lifecycle_err)
+        })
     end
 
     return { status = "shutdown", session_id = args.session_id }

--- a/src/process/session.lua
+++ b/src/process/session.lua
@@ -42,6 +42,7 @@ local function run(args: SessionArgs)
     end
 
     local session_data = session_reader:state()
+    local session_config = session_data.config or {}
     if session_data.status == consts.STATUS.FAILED then
         error("Cannot open failed session")
     end
@@ -55,7 +56,7 @@ local function run(args: SessionArgs)
 
     -- Initialize agent context using session config
     local agent_opts = {
-        enable_cache = session_data.config.enable_agent_cache == true,
+        enable_cache = session_config.enable_agent_cache == true,
         context = {} :: {[string]: any},
     }
     local agent_ctx = agent_context.new(agent_opts)
@@ -63,24 +64,24 @@ local function run(args: SessionArgs)
     -- Re-apply persisted declarative trait/tool overlays so they survive a process
     -- restart. A list overlay replaces the agent's own set; `false` is the cleared
     -- marker written on an agent switch (config can't drop a key) and is skipped.
-    if type(session_data.config.active_traits) == "table" then
-        agent_ctx:set_active_traits(session_data.config.active_traits)
+    if type(session_config.active_traits) == "table" then
+        agent_ctx:set_active_traits(session_config.active_traits)
     end
-    if type(session_data.config.active_tools) == "table" then
-        agent_ctx:set_active_tools(session_data.config.active_tools)
+    if type(session_config.active_tools) == "table" then
+        agent_ctx:set_active_tools(session_config.active_tools)
     end
 
     -- Configure delegation if enabled
-    if session_data.config.delegation_func_id then
+    if session_config.delegation_func_id then
         local delegation_schema = nil
-        local tool_schema, schema_err = tools.get_tool_schema(session_data.config.delegation_func_id)
+        local tool_schema, schema_err = tools.get_tool_schema(session_config.delegation_func_id)
         if tool_schema and tool_schema.schema then
             delegation_schema = tool_schema.schema
         end
 
         agent_ctx:configure_delegate_tools({
             enabled = true,
-            description_suffix = session_data.config.delegation_description_suffix,
+            description_suffix = session_config.delegation_description_suffix,
             default_schema = delegation_schema
         })
     end
@@ -91,7 +92,7 @@ local function run(args: SessionArgs)
         reader = session_reader,
         writer = session_writer,
         upstream = session_upstream,
-        config = (session_data.config or {}) :: {[string]: any},
+        config = session_config,
         agent_ctx = agent_ctx,
         lifecycle_state = {},
         queue_empty_callback = function()
@@ -132,35 +133,35 @@ local function run(args: SessionArgs)
     if args.create then
         session_writer:update_status(consts.STATUS.IDLE)
 
-        if session_data.config.agent_id and session_data.config.agent_id ~= "" then
+        if session_config.agent_id and session_config.agent_id ~= "" then
             bus:queue_op({
                 type = consts.OP_TYPE.AGENT_CHANGE,
-                agent_id = session_data.config.agent_id,
+                agent_id = session_config.agent_id,
                 init = true
             })
         end
 
-        if session_data.config.model and session_data.config.model ~= "" then
+        if session_config.model and session_config.model ~= "" then
             bus:queue_op({
                 type = consts.OP_TYPE.MODEL_CHANGE,
-                model = session_data.config.model,
+                model = session_config.model,
                 init = true
             })
         end
 
-        if session_data.config.init_function_id and session_data.config.init_function_id ~= "" then
+        if session_config.init_function_id and session_config.init_function_id ~= "" then
             bus:queue_op({
                 type = consts.OP_TYPE.EXECUTE_FUNCTION,
-                function_id = session_data.config.init_function_id,
-                function_params = session_data.config.init_function_params,
+                function_id = session_config.init_function_id,
+                function_params = session_config.init_function_params,
             })
         end
     end
 
     -- Send initial session data to client
     session_upstream:update_session({
-        agent = session_data.config.agent_id,
-        model = session_data.config.model,
+        agent = session_config.agent_id,
+        model = session_config.model,
         status = consts.STATUS.IDLE,
         last_message_date = session_data.last_message_date,
         public_meta = session_data.public_meta,

--- a/src/process/session_handlers.lua
+++ b/src/process/session_handlers.lua
@@ -12,6 +12,30 @@ type BackgroundTriggerResult = {
 
 local session_handlers = {}
 
+local function checkpoint_options_from_agent(op): table
+    local agent_options = op and op.agent_options
+    if type(agent_options) ~= "table" or type(agent_options.checkpoint) ~= "table" then
+        return {}
+    end
+
+    return agent_options.checkpoint
+end
+
+local function resolve_checkpoint_config(ctx, op): (string?, number?)
+    local checkpoint_options = checkpoint_options_from_agent(op)
+    local function_id = checkpoint_options.function_id or ctx.config.checkpoint_function_id
+    if type(function_id) ~= "string" or function_id == "" then
+        function_id = nil
+    end
+    local threshold = tonumber(checkpoint_options.token_threshold)
+
+    if not threshold then
+        threshold = tonumber(ctx.config.token_checkpoint_threshold)
+    end
+
+    return function_id, threshold
+end
+
 function session_handlers.execute_function(ctx, op)
     if not op.function_id then
         return nil, "Function ID is required"
@@ -117,13 +141,14 @@ function session_handlers.check_background_triggers(ctx, op)
 
     local session_data = ctx.reader:state()
 
-    if ctx.config.checkpoint_function_id and tokens.prompt_tokens then
-        local token_threshold = ctx.config.token_checkpoint_threshold
+    local checkpoint_function_id, token_threshold = resolve_checkpoint_config(ctx, op)
+    if checkpoint_function_id and tokens.prompt_tokens and token_threshold and token_threshold > 0 then
 
         if tokens.prompt_tokens > token_threshold then
             checkpoint_needed = true
             table.insert(next_ops, {
                 type = consts.OP_TYPE.CREATE_CHECKPOINT,
+                checkpoint_function_id = checkpoint_function_id,
                 checkpoint_id = message_id,
                 message_id = message_id,
                 trigger_tokens = tokens.prompt_tokens
@@ -198,7 +223,9 @@ function session_handlers.generate_title(ctx, op)
 end
 
 function session_handlers.create_checkpoint(ctx, op)
-    if not ctx.config.checkpoint_function_id then
+    local checkpoint_function_id = op.checkpoint_function_id or ctx.config.checkpoint_function_id
+
+    if not checkpoint_function_id then
         return nil, "No summary function ID configured"
     end
 
@@ -211,7 +238,7 @@ function session_handlers.create_checkpoint(ctx, op)
         session_context = {}
     end
 
-    local result, func_err = funcs.new():with_context(session_context):call(ctx.config.checkpoint_function_id :: string, {
+    local result, func_err = funcs.new():with_context(session_context):call(checkpoint_function_id :: string, {
         session_id = ctx.session_id
     })
 

--- a/src/process/session_handlers.lua
+++ b/src/process/session_handlers.lua
@@ -317,9 +317,11 @@ function session_handlers.agent_change(ctx, op)
     if not op.agent_id then
         return nil, "Agent ID is required"
     end
-
     local session_data = ctx.reader:state()
     local current_config = session_data.config or {}
+    if type(ctx.config) ~= "table" then
+        ctx.config = current_config
+    end
     local previous_agent = current_config.agent_id
     local previous_model = current_config.model
 
@@ -375,9 +377,11 @@ function session_handlers.model_change(ctx, op)
     if not op.model then
         return nil, "Model name is required"
     end
-
     local session_data = ctx.reader:state()
     local current_config = session_data.config or {}
+    if type(ctx.config) ~= "table" then
+        ctx.config = current_config
+    end
     local previous_model = current_config.model
 
     current_config.model = op.model

--- a/src/process/session_handlers_test.lua
+++ b/src/process/session_handlers_test.lua
@@ -1,0 +1,106 @@
+local test = require("test")
+local session_handlers = require("session_handlers")
+
+local function mock_ctx(state_config)
+    local captured = {
+        persisted = nil :: table?,
+        upstream = nil :: table?,
+        system_messages = 0,
+        developer_messages = 0,
+        switched_agent = nil :: string?,
+        switched_model = nil :: string?,
+    }
+
+    local ctx = {
+        config = nil,
+        reader = {
+            state = function()
+                return { config = state_config or {} }
+            end,
+            reset = function()
+                return true
+            end,
+        },
+        writer = {
+            update_meta = function(self, meta)
+                captured.persisted = meta.config
+                return true
+            end,
+            add_message = function(self, message_type)
+                if message_type == "system" then
+                    captured.system_messages = captured.system_messages + 1
+                elseif message_type == "developer" then
+                    captured.developer_messages = captured.developer_messages + 1
+                end
+                return "msg-id"
+            end,
+        },
+        upstream = {
+            update_session = function(self, payload)
+                captured.upstream = payload
+            end,
+        },
+        agent_ctx = {
+            current_model = "model:new",
+            switch_to_agent = function(self, agent_id)
+                captured.switched_agent = agent_id
+                self.current_model = "model:new"
+                return true
+            end,
+            switch_to_model = function(self, model)
+                captured.switched_model = model
+                return true
+            end,
+        },
+    }
+
+    return ctx, captured
+end
+
+local function define_tests()
+    describe("session_handlers config normalization", function()
+        it("agent_change tolerates a missing live ctx.config", function()
+            local ctx, captured = mock_ctx({
+                agent_id = "agent:old",
+                model = "model:old",
+            })
+
+            local result, err = session_handlers.agent_change(ctx, {
+                agent_id = "agent:new",
+                init = true,
+            })
+
+            test.is_nil(err)
+            test.not_nil(result)
+            test.not_nil(ctx.config)
+            test.eq(ctx.config.agent_id, "agent:new")
+            test.eq(ctx.config.model, "model:new")
+            test.eq(captured.switched_agent, "agent:new")
+            test.eq((captured.persisted or {}).agent_id, "agent:new")
+            test.eq((captured.persisted or {}).model, "model:new")
+            test.eq((captured.upstream or {}).agent, "agent:new")
+            test.eq((captured.upstream or {}).model, "model:new")
+        end)
+
+        it("model_change tolerates a missing live ctx.config", function()
+            local ctx, captured = mock_ctx({
+                agent_id = "agent:current",
+                model = "model:old",
+            })
+
+            local result, err = session_handlers.model_change(ctx, {
+                model = "model:new",
+            })
+
+            test.is_nil(err)
+            test.not_nil(result)
+            test.not_nil(ctx.config)
+            test.eq(ctx.config.model, "model:new")
+            test.eq(captured.switched_model, "model:new")
+            test.eq((captured.persisted or {}).model, "model:new")
+            test.eq((captured.upstream or {}).model, "model:new")
+        end)
+    end)
+end
+
+return test.run_cases(define_tests)

--- a/src/prompt_builder.lua
+++ b/src/prompt_builder.lua
@@ -8,9 +8,28 @@ type BuildOptions = {
 }
 
 local prompt_builder = {
-    _prompt = require("prompt"),
-    _upload_repo = require("upload_repo")
+    _prompt = require("prompt")
 }
+
+local function resolve_file(file_uuid: string, options: table)
+    local resolver = options.file_resolver or options.file_lookup
+    if type(resolver) == "function" then
+        local ok, upload_or_err, err = pcall(resolver, file_uuid)
+        if ok and not err and upload_or_err then
+            return upload_or_err
+        end
+    end
+
+    local upload_repo = options.upload_repo
+    if type(upload_repo) == "table" and type(upload_repo.get) == "function" then
+        local ok, upload, err = pcall(upload_repo.get, file_uuid)
+        if ok and not err and upload then
+            return upload
+        end
+    end
+
+    return nil
+end
 
 function prompt_builder.build(messages, contexts, session_meta, options)
     if not messages then
@@ -47,12 +66,12 @@ function prompt_builder.build(messages, contexts, session_meta, options)
             if include_files and metadata.file_uuids and #metadata.file_uuids > 0 then
                 local file_info = {}
                 for _, file_uuid in ipairs(metadata.file_uuids) do
-                    local upload, err = prompt_builder._upload_repo.get(file_uuid)
-                    if not err and upload then
+                    if type(file_uuid) == "string" then
+                        local upload = resolve_file(file_uuid, options)
                         table.insert(file_info, {
-                            filename = upload.metadata and upload.metadata.filename or "Unknown filename",
-                            size = upload.size or 0,
-                            type = upload.mime_type or "Unknown type",
+                            filename = upload and upload.metadata and upload.metadata.filename or "Unknown filename",
+                            size = upload and upload.size or 0,
+                            type = upload and upload.mime_type or "Unknown type",
                             uuid = file_uuid
                         })
                     end

--- a/src/run_context/_index.yaml
+++ b/src/run_context/_index.yaml
@@ -2,8 +2,8 @@ version: "1.0"
 namespace: wippy.session.run_context
 
 entries:
-  # wippy.session.run_context:lib
-  - name: lib
+  # wippy.session.run_context:run_context_lib
+  - name: run_context_lib
     kind: library.lua
     meta:
       comment: Session-backed implementation library for wippy.agent:run_context.
@@ -47,7 +47,7 @@ entries:
         - context
     source: file://get_context.lua
     imports:
-      run_context: wippy.session.run_context:lib
+      run_context: wippy.session.run_context:run_context_lib
     method: handle
 
   # wippy.session.run_context:get_history
@@ -61,7 +61,7 @@ entries:
         - history
     source: file://get_history.lua
     imports:
-      run_context: wippy.session.run_context:lib
+      run_context: wippy.session.run_context:run_context_lib
     method: handle
 
   # wippy.session.run_context:get_prompt
@@ -75,7 +75,7 @@ entries:
         - prompt
     source: file://get_prompt.lua
     imports:
-      run_context: wippy.session.run_context:lib
+      run_context: wippy.session.run_context:run_context_lib
     method: handle
 
   # wippy.session.run_context:run_context_test

--- a/src/run_context/_index.yaml
+++ b/src/run_context/_index.yaml
@@ -1,0 +1,126 @@
+version: "1.0"
+namespace: wippy.session.run_context
+
+entries:
+  # wippy.session.run_context:lib
+  - name: lib
+    kind: library.lua
+    meta:
+      comment: Session-backed implementation library for wippy.agent:run_context.
+      tags:
+        - session
+        - agents
+        - context
+        - history
+        - prompt
+    source: file://lib.lua
+    modules:
+      - json
+    imports:
+      session: wippy.session.persist:reader
+      prompt_builder: wippy.session:prompt_builder
+
+  # wippy.session.run_context:binding
+  - name: binding
+    kind: contract.binding
+    meta:
+      comment: Session-backed run-context reader for agent traits and tools.
+      tags:
+        - session
+        - agents
+        - context
+    contracts:
+      - contract: wippy.agent:run_context
+        methods:
+          get_context: wippy.session.run_context:get_context
+          get_history: wippy.session.run_context:get_history
+          get_prompt: wippy.session.run_context:get_prompt
+
+  # wippy.session.run_context:get_context
+  - name: get_context
+    kind: function.lua
+    meta:
+      comment: Read the current session agent-run context.
+      tags:
+        - session
+        - agents
+        - context
+    source: file://get_context.lua
+    imports:
+      run_context: wippy.session.run_context:lib
+    method: handle
+
+  # wippy.session.run_context:get_history
+  - name: get_history
+    kind: function.lua
+    meta:
+      comment: Read a bounded session agent-run history slice.
+      tags:
+        - session
+        - agents
+        - history
+    source: file://get_history.lua
+    imports:
+      run_context: wippy.session.run_context:lib
+    method: handle
+
+  # wippy.session.run_context:get_prompt
+  - name: get_prompt
+    kind: function.lua
+    meta:
+      comment: Build a prompt from a bounded session agent-run slice.
+      tags:
+        - session
+        - agents
+        - prompt
+    source: file://get_prompt.lua
+    imports:
+      run_context: wippy.session.run_context:lib
+    method: handle
+
+  # wippy.session.run_context:run_context_test
+  - name: test_security_policy
+    kind: security.policy
+    meta:
+      scope: dev
+      comment: Allows the run-context contract test to read its seeded session.
+      tags:
+        - session
+        - agents
+        - run-context
+        - test
+    policy:
+      actions: "*"
+      resources: "*"
+      effect: allow
+    groups:
+      - test_group
+
+  # wippy.session.run_context:run_context_test
+  - name: run_context_test
+    kind: function.lua
+    meta:
+      type: test
+      suite: session
+      comment: Contract-level tests for the session run-context child binding.
+      tags:
+        - session
+        - agents
+        - run-context
+        - test
+    source: file://run_context_test.lua
+    modules:
+      - contract
+      - json
+      - security
+      - sql
+      - uuid
+    imports:
+      consts: wippy.session:consts
+      context_repo: wippy.session.persist:context_repo
+      message_repo: wippy.session.persist:message_repo
+      session_contexts_repo: wippy.session.persist:session_contexts_repo
+      session_repo: wippy.session.persist:session_repo
+      test: wippy.test:test
+      wait_for_boot: app:wait_for_boot
+    method: run_tests

--- a/src/run_context/get_context.lua
+++ b/src/run_context/get_context.lua
@@ -1,0 +1,9 @@
+local run_context = require("run_context")
+
+local M = {}
+
+function M.handle(args)
+    return run_context.get_context(args)
+end
+
+return M

--- a/src/run_context/get_history.lua
+++ b/src/run_context/get_history.lua
@@ -1,0 +1,9 @@
+local run_context = require("run_context")
+
+local M = {}
+
+function M.handle(args)
+    return run_context.get_history(args)
+end
+
+return M

--- a/src/run_context/get_prompt.lua
+++ b/src/run_context/get_prompt.lua
@@ -1,0 +1,9 @@
+local run_context = require("run_context")
+
+local M = {}
+
+function M.handle(args)
+    return run_context.get_prompt(args)
+end
+
+return M

--- a/src/run_context/lib.lua
+++ b/src/run_context/lib.lua
@@ -1,0 +1,314 @@
+local json = require("json")
+local consts = require("consts")
+local session = require("session")
+local prompt_builder = require("prompt_builder")
+
+local M = {}
+
+type Selector = {
+    mode: string?,
+    last: any?,
+    from_id: string?,
+    to_id: string?,
+    checkpoint_id: string?,
+    max_chars: any?,
+}
+
+local function host_session_id(args)
+    local host = type(args) == "table" and args.host or nil
+    local session_id = host and host.session_id or (type(args) == "table" and args.session_id)
+    if type(session_id) ~= "string" or session_id == "" then
+        return nil, "host.session_id is required"
+    end
+    return session_id, nil
+end
+
+local function open_reader(args)
+    local session_id, id_err = host_session_id(args)
+    if id_err then
+        return nil, id_err
+    end
+
+    local reader, err = session.open(session_id)
+    if not reader then
+        return nil, err or "failed to open session"
+    end
+
+    return reader, nil
+end
+
+local function selector(args): Selector
+    local raw = type(args) == "table" and args.selector or nil
+    if type(raw) ~= "table" then
+        return { mode = "since_checkpoint" } :: Selector
+    end
+    return raw :: Selector
+end
+
+local function without_anchor(messages, anchor_id)
+    if type(anchor_id) ~= "string" or anchor_id == "" then
+        return messages or {}
+    end
+
+    local out = {}
+    for _, msg in ipairs(messages or {}) do
+        if msg.message_id ~= anchor_id then
+            out[#out + 1] = msg
+        end
+    end
+    return out
+end
+
+local function query_messages(reader, sel)
+    local mode = sel.mode or "since_checkpoint"
+    local query = reader:messages()
+
+    if mode == "window" then
+        local count = sel.last == nil and 20 or tonumber(sel.last)
+        if not count or count <= 0 then
+            return nil, "selector.last must be positive for window"
+        end
+        return query:last(count):all()
+    end
+
+    if mode == "since_id" then
+        if type(sel.from_id) ~= "string" or sel.from_id == "" then
+            return nil, "selector.from_id is required for since_id"
+        end
+        local messages, err = query:after(sel.from_id):all()
+        if err then
+            return nil, err
+        end
+        return without_anchor(messages, sel.from_id), nil
+    end
+
+    if mode == "range" then
+        if type(sel.from_id) == "string" and sel.from_id ~= ""
+           and type(sel.to_id) == "string" and sel.to_id ~= ""
+           and sel.from_id == sel.to_id then
+            return {}, nil
+        end
+        if type(sel.from_id) == "string" and sel.from_id ~= "" then
+            query = query:after(sel.from_id)
+        end
+        local messages, err = query:all()
+        if err then
+            return nil, err
+        end
+        messages = without_anchor(messages, sel.from_id)
+        if type(sel.to_id) ~= "string" or sel.to_id == "" then
+            return messages, nil
+        end
+        local out = {}
+        for _, msg in ipairs(messages or {}) do
+            out[#out + 1] = msg
+            if msg.message_id == sel.to_id then
+                break
+            end
+        end
+        return out, nil
+    end
+
+    if mode == "all" then
+        return query:all()
+    end
+
+    if mode == "checkpoint" then
+        if type(sel.checkpoint_id) ~= "string" or sel.checkpoint_id == "" then
+            return nil, "selector.checkpoint_id is required for checkpoint"
+        end
+        local messages, err = query:after(sel.checkpoint_id):all()
+        if err then
+            return nil, err
+        end
+        return without_anchor(messages, sel.checkpoint_id), nil
+    end
+
+    if mode == "since_checkpoint" then
+        local checkpoint_id = reader:get_context(consts.CONTEXT_KEYS.CURRENT_CHECKPOINT_ID)
+        local messages, err = query:from_checkpoint():all()
+        if err then
+            return nil, err
+        end
+        return without_anchor(messages, checkpoint_id), nil
+    end
+
+    return nil, "unknown selector mode: " .. tostring(mode)
+end
+
+local function decode_data(data)
+    if type(data) ~= "string" then
+        return data
+    end
+    local decoded, err = json.decode(data)
+    if not err then
+        return decoded
+    end
+    return data
+end
+
+local function normalize_event(msg)
+    return {
+        id = msg.message_id,
+        role = msg.type,
+        content = decode_data(msg.data),
+        raw_content = msg.data,
+        metadata = type(msg.metadata) == "table" and msg.metadata or {},
+        created_at = msg.date
+    }
+end
+
+local function clamp_events(events, max_chars)
+    local limit = tonumber(max_chars)
+    if not limit or limit <= 0 then
+        return events, false
+    end
+
+    local total = 0
+    local out = {}
+    local truncated = false
+    for _, event in ipairs(events) do
+        local content = event.raw_content or event.content or ""
+        if type(content) ~= "string" then
+            local encoded = json.encode(content)
+            content = encoded or tostring(content)
+        end
+        local next_total = total + #content
+        if next_total > limit then
+            truncated = true
+            break
+        end
+        total = next_total
+        out[#out + 1] = event
+    end
+    return out, truncated
+end
+
+local function history_result(reader, args)
+    local sel = selector(args)
+    local messages, err = query_messages(reader, sel)
+    if err then
+        return nil, err
+    end
+
+    local events = {}
+    for _, msg in ipairs(messages or {}) do
+        events[#events + 1] = normalize_event(msg)
+    end
+    local truncated
+    events, truncated = clamp_events(events, sel.max_chars)
+
+    local first = events[1]
+    local last = events[#events]
+    return {
+        events = events,
+        range = {
+            from_id = first and first.id or nil,
+            to_id = last and last.id or nil,
+            checkpoint_id = sel.checkpoint_id
+        },
+        truncated = truncated == true,
+        count = #events
+    }, nil
+end
+
+function M.get_context(args)
+    local reader, err = open_reader(args)
+    if not reader then
+        return nil, err
+    end
+
+    local context, ctx_err = reader:get_full_context()
+    if ctx_err then
+        return nil, ctx_err
+    end
+
+    return {
+        context = context or {},
+        host = type(args) == "table" and args.host or nil,
+        agent = type(args) == "table" and args.agent or nil
+    }, nil
+end
+
+function M.get_history(args)
+    local reader, err = open_reader(args)
+    if not reader then
+        return nil, err
+    end
+
+    return history_result(reader, args)
+end
+
+local function prompt_to_text(messages)
+    local parts = {}
+    for _, msg in ipairs(messages or {}) do
+        local role = tostring(msg.role or "message")
+        local text = ""
+        if type(msg.content) == "table" then
+            for _, item in ipairs(msg.content) do
+                if type(item) == "table" and item.text then
+                    text = text .. tostring(item.text)
+                elseif type(item) == "string" then
+                    text = text .. item
+                end
+            end
+        elseif msg.content ~= nil then
+            text = tostring(msg.content)
+        end
+        parts[#parts + 1] = string.format("[%s] %s", role, text)
+    end
+    return table.concat(parts, "\n")
+end
+
+function M.get_prompt(args)
+    local reader, err = open_reader(args)
+    if not reader then
+        return nil, err
+    end
+
+    local hist, hist_err = history_result(reader, args)
+    if hist_err then
+        return nil, hist_err
+    end
+
+    local messages = {}
+    for _, event in ipairs(hist.events or {}) do
+        messages[#messages + 1] = {
+            message_id = event.id,
+            type = event.role,
+            data = event.raw_content,
+            metadata = event.metadata or {}
+        }
+    end
+
+    local contexts, ctx_err = reader:contexts():all()
+    if ctx_err then
+        contexts = {}
+    end
+
+    local built, build_err = prompt_builder.build(messages, contexts, reader:state(), {
+        include_contexts = args and args.include_contexts ~= false,
+        include_files = args and args.include_files ~= false,
+        cache_markers = args and args.cache_markers ~= false
+    })
+    if build_err then
+        return nil, build_err
+    end
+
+    local prompt_messages = built:get_messages()
+    local format = args and args.format or "messages"
+    local result = {
+        range = hist.range,
+        truncated = hist.truncated
+    }
+    if format == "text" or format == "both" then
+        result.text = prompt_to_text(prompt_messages)
+    end
+    if format ~= "text" then
+        result.messages = prompt_messages
+    end
+
+    return result, nil
+end
+
+return M

--- a/src/run_context/run_context_test.lua
+++ b/src/run_context/run_context_test.lua
@@ -1,0 +1,447 @@
+local contract = require("contract")
+local context_repo = require("context_repo")
+local consts = require("consts")
+local json = require("json")
+local message_repo = require("message_repo")
+local security = require("security")
+local session_contexts_repo = require("session_contexts_repo")
+local session_repo = require("session_repo")
+local sql = require("sql")
+local test = require("test")
+local uuid = require("uuid")
+local wait_for_boot = require("wait_for_boot")
+
+local CONTRACT_ID = "wippy.agent:run_context"
+local BINDING_ID = "wippy.session.run_context:binding"
+local TEST_ACTOR_ID = "session-run-context-test@wippy.local"
+
+local test_data = {
+    session_id = uuid.v7(),
+    context_id = uuid.v7(),
+    summary_id = uuid.v7(),
+    user_message_id = uuid.v7(),
+    assistant_message_id = uuid.v7(),
+}
+
+local function open_binding()
+    local def, def_err = contract.get(CONTRACT_ID)
+    test.is_nil(def_err, "contract.get: " .. tostring(def_err))
+    test.not_nil(def)
+
+    local actor = security.new_actor(TEST_ACTOR_ID, { source = "run_context_test" })
+    local scope, scope_err = security.named_scope("wippy.session.run_context:test_group")
+    test.is_nil(scope_err, "security.named_scope: " .. tostring(scope_err))
+    test.not_nil(scope)
+
+    local instance, open_err = def
+        :with_actor(actor)
+        :with_scope(scope)
+        :open(BINDING_ID)
+    test.is_nil(open_err, "contract.open: " .. tostring(open_err))
+    test.not_nil(instance)
+    return instance
+end
+
+local function current_user_id()
+    return TEST_ACTOR_ID
+end
+
+local function cleanup()
+    local db_resource = consts.get_db_resource()
+    local db, err = sql.get(db_resource)
+    if err then
+        return
+    end
+
+    local tx, tx_err = db:begin()
+    if tx_err then
+        db:release()
+        return
+    end
+
+    tx:execute("DELETE FROM messages WHERE session_id = $1", { test_data.session_id })
+    tx:execute("DELETE FROM session_contexts WHERE session_id = $1", { test_data.session_id })
+    tx:execute("DELETE FROM sessions WHERE session_id = $1", { test_data.session_id })
+    tx:execute("DELETE FROM contexts WHERE context_id = $1", { test_data.context_id })
+
+    local _, commit_err = tx:commit()
+    if commit_err then
+        tx:rollback()
+    end
+    db:release()
+end
+
+local function setup_session()
+    wait_for_boot.run()
+    cleanup()
+
+    local context_json, encode_err = json.encode({
+        topic = "run-context",
+        nested = { enabled = true },
+        current_checkpoint_id = test_data.user_message_id
+    })
+    test.is_nil(encode_err)
+
+    local context, context_err = context_repo.create(test_data.context_id, "primary", context_json)
+    test.is_nil(context_err, "context create: " .. tostring(context_err))
+    test.not_nil(context)
+
+    local session, session_err = session_repo.create(
+        test_data.session_id,
+        current_user_id(),
+        test_data.context_id,
+        "Run Context Test",
+        "test",
+        { purpose = "run_context" },
+        { model = "test-model" }
+    )
+    test.is_nil(session_err, "session create: " .. tostring(session_err))
+    test.not_nil(session)
+
+    local user_message, user_err = message_repo.create(
+        test_data.user_message_id,
+        test_data.session_id,
+        "user",
+        "hello from session",
+        { trace = "user" }
+    )
+    test.is_nil(user_err, "user message create: " .. tostring(user_err))
+    test.not_nil(user_message)
+
+    local assistant_message, assistant_err = message_repo.create(
+        test_data.assistant_message_id,
+        test_data.session_id,
+        "assistant",
+        "hello from assistant",
+        { trace = "assistant" }
+    )
+    test.is_nil(assistant_err, "assistant message create: " .. tostring(assistant_err))
+    test.not_nil(assistant_message)
+
+    local summary, summary_err = session_contexts_repo.create(
+        test_data.summary_id,
+        test_data.session_id,
+        "conversation_summary",
+        "existing summary"
+    )
+    test.is_nil(summary_err, "summary create: " .. tostring(summary_err))
+    test.not_nil(summary)
+end
+
+local function define_tests()
+    test.describe("session run_context binding", function()
+        before_all(setup_session)
+        after_all(cleanup)
+
+        test.it("routes get_context through the child binding function", function()
+            local result, err = open_binding():get_context({ host = { kind = "session" } })
+            test.is_nil(result)
+            test.contains(tostring(err), "host.session_id is required")
+        end)
+
+        test.it("routes get_history through the child binding function", function()
+            local result, err = open_binding():get_history({ host = { kind = "session" } })
+            test.is_nil(result)
+            test.contains(tostring(err), "host.session_id is required")
+        end)
+
+        test.it("routes get_prompt through the child binding function", function()
+            local result, err = open_binding():get_prompt({ host = { kind = "session" } })
+            test.is_nil(result)
+            test.contains(tostring(err), "host.session_id is required")
+        end)
+
+        test.it("reads context through the child binding function", function()
+            local result, err = open_binding():get_context({
+                host = { kind = "session", session_id = test_data.session_id },
+                agent = { id = "agent:test", model = "test-model" }
+            })
+
+            test.is_nil(err, "get_context: " .. tostring(err))
+            test.not_nil(result)
+            test.eq(result.host.session_id, test_data.session_id)
+            test.eq(result.agent.id, "agent:test")
+            test.eq(result.context.topic, "run-context")
+            test.is_true(result.context.nested.enabled)
+        end)
+
+        test.it("reads a bounded history slice through the child binding function", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "window", last = 1 }
+            })
+
+            test.is_nil(err, "get_history: " .. tostring(err))
+            test.not_nil(result)
+            test.eq(#result.events, 1)
+            test.eq(result.events[1].id, test_data.assistant_message_id)
+            test.eq(result.events[1].role, "assistant")
+            test.eq(result.events[1].content, "hello from assistant")
+            test.eq(result.range.from_id, test_data.assistant_message_id)
+            test.eq(result.range.to_id, test_data.assistant_message_id)
+            test.is_false(result.truncated)
+        end)
+
+        test.it("reads all history in chronological order", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "all" }
+            })
+
+            test.is_nil(err, "get_history all: " .. tostring(err))
+            test.eq(#result.events, 2)
+            test.eq(result.events[1].id, test_data.user_message_id)
+            test.eq(result.events[2].id, test_data.assistant_message_id)
+            test.eq(result.range.from_id, test_data.user_message_id)
+            test.eq(result.range.to_id, test_data.assistant_message_id)
+        end)
+
+        test.it("uses a default window size when last is omitted", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "window" }
+            })
+
+            test.is_nil(err, "get_history window default: " .. tostring(err))
+            test.eq(#result.events, 2)
+            test.eq(result.events[1].id, test_data.user_message_id)
+            test.eq(result.events[2].id, test_data.assistant_message_id)
+        end)
+
+        test.it("rejects non-positive window sizes", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "window", last = 0 }
+            })
+
+            test.is_nil(result)
+            test.contains(tostring(err), "selector.last must be positive")
+        end)
+
+        test.it("rejects non-numeric window sizes", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "window", last = "later" }
+            })
+
+            test.is_nil(result)
+            test.contains(tostring(err), "selector.last must be positive")
+        end)
+
+        test.it("requires from_id for since_id", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "since_id" }
+            })
+
+            test.is_nil(result)
+            test.contains(tostring(err), "selector.from_id is required")
+        end)
+
+        test.it("treats since_id as exclusive", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "since_id",
+                    from_id = test_data.user_message_id
+                }
+            })
+
+            test.is_nil(err, "get_history since_id: " .. tostring(err))
+            test.eq(#result.events, 1)
+            test.eq(result.events[1].id, test_data.assistant_message_id)
+            test.eq(result.range.from_id, test_data.assistant_message_id)
+            test.eq(result.range.to_id, test_data.assistant_message_id)
+        end)
+
+        test.it("treats range without from_id as beginning of history", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "range",
+                    to_id = test_data.user_message_id
+                }
+            })
+
+            test.is_nil(err, "get_history range from beginning: " .. tostring(err))
+            test.eq(#result.events, 1)
+            test.eq(result.events[1].id, test_data.user_message_id)
+            test.eq(result.range.from_id, test_data.user_message_id)
+            test.eq(result.range.to_id, test_data.user_message_id)
+        end)
+
+        test.it("treats range as exclusive from_id and inclusive to_id", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "range",
+                    from_id = test_data.user_message_id,
+                    to_id = test_data.assistant_message_id
+                }
+            })
+
+            test.is_nil(err, "get_history range: " .. tostring(err))
+            test.eq(#result.events, 1)
+            test.eq(result.events[1].id, test_data.assistant_message_id)
+            test.eq(result.range.from_id, test_data.assistant_message_id)
+            test.eq(result.range.to_id, test_data.assistant_message_id)
+        end)
+
+        test.it("returns an empty range when from_id and to_id are the same", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "range",
+                    from_id = test_data.user_message_id,
+                    to_id = test_data.user_message_id
+                }
+            })
+
+            test.is_nil(err, "get_history empty range: " .. tostring(err))
+            test.eq(#result.events, 0)
+            test.is_nil(result.range.from_id)
+            test.is_nil(result.range.to_id)
+        end)
+
+        test.it("treats range without to_id as open ended", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "range",
+                    from_id = test_data.user_message_id
+                }
+            })
+
+            test.is_nil(err, "get_history open range: " .. tostring(err))
+            test.eq(#result.events, 1)
+            test.eq(result.events[1].id, test_data.assistant_message_id)
+            test.eq(result.range.from_id, test_data.assistant_message_id)
+            test.eq(result.range.to_id, test_data.assistant_message_id)
+        end)
+
+        test.it("requires checkpoint_id for explicit checkpoint mode", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "checkpoint" }
+            })
+
+            test.is_nil(result)
+            test.contains(tostring(err), "selector.checkpoint_id is required")
+        end)
+
+        test.it("treats explicit checkpoints as exclusive anchors", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "checkpoint",
+                    checkpoint_id = test_data.user_message_id
+                }
+            })
+
+            test.is_nil(err, "get_history checkpoint: " .. tostring(err))
+            test.eq(#result.events, 1)
+            test.eq(result.events[1].id, test_data.assistant_message_id)
+        end)
+
+        test.it("uses the current checkpoint as an exclusive anchor by default", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id }
+            })
+
+            test.is_nil(err, "get_history since_checkpoint: " .. tostring(err))
+            test.eq(#result.events, 1)
+            test.eq(result.events[1].id, test_data.assistant_message_id)
+        end)
+
+        test.it("rejects unknown selector modes", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "laterish" }
+            })
+
+            test.is_nil(result)
+            test.contains(tostring(err), "unknown selector mode")
+        end)
+
+        test.it("applies max_chars after slicing and reports truncation", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "all",
+                    max_chars = 20
+                }
+            })
+
+            test.is_nil(err, "get_history max_chars: " .. tostring(err))
+            test.eq(#result.events, 1)
+            test.eq(result.events[1].id, test_data.user_message_id)
+            test.is_true(result.truncated)
+            test.eq(result.range.from_id, test_data.user_message_id)
+            test.eq(result.range.to_id, test_data.user_message_id)
+        end)
+
+        test.it("ignores root max_chars for history slices", function()
+            local result, err = open_binding():get_history({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "all" },
+                max_chars = 20
+            })
+
+            test.is_nil(err, "get_history root max_chars: " .. tostring(err))
+            test.eq(#result.events, 2)
+            test.is_false(result.truncated)
+        end)
+
+        test.it("builds prompt text through the child binding function", function()
+            local result, err = open_binding():get_prompt({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = { mode = "all" },
+                format = "both"
+            })
+
+            test.is_nil(err, "get_prompt: " .. tostring(err))
+            test.not_nil(result)
+            test.not_nil(result.messages)
+            test.contains(result.text, "hello from session")
+            test.contains(result.text, "hello from assistant")
+            test.eq(result.range.from_id, test_data.user_message_id)
+            test.eq(result.range.to_id, test_data.assistant_message_id)
+        end)
+
+        test.it("applies selector max_chars to prompt slices", function()
+            local result, err = open_binding():get_prompt({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "all",
+                    max_chars = 20
+                },
+                format = "text"
+            })
+
+            test.is_nil(err, "get_prompt selector max_chars: " .. tostring(err))
+            test.is_true(result.truncated)
+            test.eq(result.range.from_id, test_data.user_message_id)
+            test.eq(result.range.to_id, test_data.user_message_id)
+            test.contains(result.text, "hello from session")
+            test.is_true(string.find(result.text, "hello from assistant", 1, true) == nil)
+        end)
+
+        test.it("builds prompt from the selected slice only", function()
+            local result, err = open_binding():get_prompt({
+                host = { kind = "session", session_id = test_data.session_id },
+                selector = {
+                    mode = "since_id",
+                    from_id = test_data.user_message_id
+                },
+                format = "text"
+            })
+
+            test.is_nil(err, "get_prompt selected slice: " .. tostring(err))
+            test.contains(result.text, "hello from assistant")
+            test.is_true(string.find(result.text, "hello from session", 1, true) == nil)
+            test.is_nil(result.messages)
+        end)
+    end)
+end
+
+return { run_tests = test.run_cases(define_tests) }

--- a/src/service.lua
+++ b/src/service.lua
@@ -1,0 +1,302 @@
+local json = require("json")
+local uuid = require("uuid")
+local consts = require("consts")
+local session_repo = require("session_repo")
+local context_repo = require("context_repo")
+
+type Session = {
+    session_id: string,
+    user_id: string,
+    status: string?,
+    primary_context_id: string,
+    title: string,
+    kind: string,
+    meta: {[string]: any},
+    config: {[string]: any},
+    public_meta: {[string]: any},
+    start_date: string?,
+    last_message_date: string?,
+}
+
+type EnsureSessionArgs = {
+    session_id: any?,
+    user_id: any?,
+    kind: any?,
+    title: any?,
+    meta: any?,
+    config: any?,
+    primary_context_id: any?,
+    primary_context_data: any?,
+    reset_status: any?,
+}
+
+type EnsureSessionResult = {
+    session: Session,
+    created: boolean,
+    recovered: boolean,
+    primary_context_id: string,
+}
+
+type GetSessionArgs = {
+    session_id: any?,
+    user_id: any?,
+}
+
+type UpdateSessionArgs = {
+    session_id: any?,
+    updates: any?,
+}
+
+type DeleteSessionArgs = {
+    session_id: any?,
+    user_id: any?,
+}
+
+local M = {}
+
+local function required_string(value, name)
+    if type(value) ~= "string" or value == "" then
+        return nil, name .. " is required"
+    end
+    return value, nil
+end
+
+local function optional_string(value, name, default)
+    if value == nil then
+        return default or "", nil
+    end
+    if type(value) ~= "string" then
+        return nil, name .. " must be a string"
+    end
+    return value, nil
+end
+
+local function optional_table(value, name)
+    if value == nil then
+        return {}, nil
+    end
+    if type(value) ~= "table" then
+        return nil, name .. " must be a table"
+    end
+    return value, nil
+end
+
+local function encode_context_data(data)
+    if data == nil then
+        return "{}", nil
+    end
+    if type(data) == "string" then
+        return data, nil
+    end
+    if type(data) == "table" then
+        local encoded, err = json.encode(data)
+        if err then
+            return nil, "Failed to encode primary_context_data: " .. tostring(err)
+        end
+        return encoded, nil
+    end
+    return nil, "primary_context_data must be a string or table"
+end
+
+local function should_reset_status(status)
+    return status == consts.STATUS.RUNNING or status == consts.STATUS.FAILED
+end
+
+local function normalize_existing_session(session: Session, reset_status: boolean): (EnsureSessionResult?, string?)
+    if reset_status and should_reset_status(session.status) then
+        local updated, err = session_repo.update_session_meta(session.session_id, {
+            status = consts.STATUS.IDLE
+        })
+        if err then
+            return nil, err
+        end
+        session.status = consts.STATUS.IDLE
+    end
+
+    return {
+        session = session,
+        created = false,
+        recovered = true,
+        primary_context_id = session.primary_context_id
+    }, nil
+end
+
+local function create_session(args: EnsureSessionArgs, session_id: string, user_id: string): (EnsureSessionResult?, string?)
+    local title, title_err = optional_string(args.title, "title", "")
+    if title_err then
+        return nil, title_err
+    end
+
+    local kind, kind_err = optional_string(args.kind, "kind", consts.SESSION_KINDS.DEFAULT)
+    if kind_err then
+        return nil, kind_err
+    end
+
+    local meta, meta_err = optional_table(args.meta, "meta")
+    if meta_err then
+        return nil, meta_err
+    end
+
+    local config, config_err = optional_table(args.config, "config")
+    if config_err then
+        return nil, config_err
+    end
+
+    local context_id = args.primary_context_id
+    if context_id == nil then
+        context_id = uuid.v7()
+    end
+    local normalized_context_id, context_id_err = required_string(context_id, "primary_context_id")
+    if context_id_err then
+        return nil, context_id_err
+    end
+    context_id = normalized_context_id :: string
+
+    local context_data, data_err = encode_context_data(args.primary_context_data)
+    if data_err then
+        return nil, data_err
+    end
+
+    local _, context_err = context_repo.create(
+        context_id,
+        consts.CONTEXT_TYPES.SESSION,
+        context_data
+    )
+    if context_err then
+        return nil, context_err
+    end
+
+    local session, session_err = session_repo.create(
+        session_id,
+        user_id,
+        context_id,
+        title,
+        kind,
+        meta,
+        config
+    )
+    if session_err then
+        context_repo.delete(context_id)
+        return nil, session_err
+    end
+
+    local created_session = session :: Session
+    created_session.status = consts.STATUS.IDLE
+
+    return {
+        session = created_session,
+        created = true,
+        recovered = false,
+        primary_context_id = context_id
+    } :: EnsureSessionResult, nil
+end
+
+function M.ensure(args: EnsureSessionArgs): (EnsureSessionResult?, string?)
+    if type(args) ~= "table" then
+        return nil, "args must be a table"
+    end
+
+    local session_id, session_err = required_string(args.session_id, "session_id")
+    if session_err then
+        return nil, session_err
+    end
+
+    local user_id, user_err = required_string(args.user_id, "user_id")
+    if user_err then
+        return nil, user_err
+    end
+
+    local session, get_err = session_repo.get(session_id, user_id)
+    if session then
+        return normalize_existing_session(session :: Session, args.reset_status ~= false)
+    end
+    if get_err and get_err ~= "Session not found" then
+        return nil, get_err
+    end
+
+    return create_session(args, session_id, user_id)
+end
+
+function M.get(args: GetSessionArgs): (Session?, string?)
+    if type(args) ~= "table" then
+        return nil, "args must be a table"
+    end
+
+    local session_id, session_err = required_string(args.session_id, "session_id")
+    if session_err then
+        return nil, session_err
+    end
+
+    local user_id = args.user_id
+    if user_id ~= nil then
+        local normalized, user_err = required_string(user_id, "user_id")
+        if user_err then
+            return nil, user_err
+        end
+        user_id = normalized
+    end
+
+    local session, err = session_repo.get(session_id, user_id)
+    return session :: Session?, err
+end
+
+function M.update(args: UpdateSessionArgs)
+    if type(args) ~= "table" then
+        return nil, "args must be a table"
+    end
+
+    local session_id, session_err = required_string(args.session_id, "session_id")
+    if session_err then
+        return nil, session_err
+    end
+    if type(args.updates) ~= "table" then
+        return nil, "updates table is required"
+    end
+
+    return session_repo.update_session_meta(session_id, args.updates)
+end
+
+function M.delete(args: DeleteSessionArgs)
+    if type(args) ~= "table" then
+        return nil, "args must be a table"
+    end
+
+    local session_id, session_err = required_string(args.session_id, "session_id")
+    if session_err then
+        return nil, session_err
+    end
+
+    local user_id = args.user_id
+    if user_id ~= nil then
+        local normalized, user_err = required_string(user_id, "user_id")
+        if user_err then
+            return nil, user_err
+        end
+        user_id = normalized
+    end
+
+    local session, get_err = session_repo.get(session_id, user_id)
+    if not session then
+        return nil, get_err or "Session not found"
+    end
+
+    local result, delete_err = session_repo.delete(session_id)
+    if delete_err then
+        return nil, delete_err
+    end
+
+    local context_id = session.primary_context_id
+    if type(context_id) == "string" and context_id ~= "" then
+        local _, context_err = context_repo.delete(context_id)
+        if context_err and context_err ~= "Context not found" then
+            result.primary_context_deleted = false
+            result.primary_context_error = context_err
+            return result, nil
+        end
+        result.primary_context_deleted = true
+    end
+
+    return result, nil
+end
+
+return M

--- a/src/service_test.lua
+++ b/src/service_test.lua
@@ -1,0 +1,272 @@
+local contract = require("contract")
+local consts = require("consts")
+local context_repo = require("context_repo")
+local json = require("json")
+local security = require("security")
+local service = require("service")
+local session_repo = require("session_repo")
+local sql = require("sql")
+local test = require("test")
+local uuid = require("uuid")
+local wait_for_boot = require("wait_for_boot")
+
+local CONTRACT_ID = "wippy.session:session_service"
+local BINDING_ID = "wippy.session:service_binding"
+local TEST_ACTOR_ID = "session-service-test@wippy.local"
+
+local tracked_sessions = {}
+local tracked_contexts = {}
+
+local function track_session(id)
+    tracked_sessions[#tracked_sessions + 1] = id
+    return id
+end
+
+local function track_context(id)
+    tracked_contexts[#tracked_contexts + 1] = id
+    return id
+end
+
+local function next_pair()
+    return track_session(uuid.v7()), track_context(uuid.v7())
+end
+
+local function cleanup()
+    local db_resource = consts.get_db_resource()
+    local db, err = sql.get(db_resource)
+    if err then
+        return
+    end
+
+    local tx, tx_err = db:begin()
+    if tx_err then
+        db:release()
+        return
+    end
+
+    for _, session_id in ipairs(tracked_sessions) do
+        tx:execute("DELETE FROM artifacts WHERE session_id = $1", { session_id })
+        tx:execute("DELETE FROM session_contexts WHERE session_id = $1", { session_id })
+        tx:execute("DELETE FROM messages WHERE session_id = $1", { session_id })
+        tx:execute("DELETE FROM sessions WHERE session_id = $1", { session_id })
+    end
+
+    for _, context_id in ipairs(tracked_contexts) do
+        tx:execute("DELETE FROM contexts WHERE context_id = $1", { context_id })
+    end
+
+    local _, commit_err = tx:commit()
+    if commit_err then
+        tx:rollback()
+    end
+    db:release()
+
+    tracked_sessions = {}
+    tracked_contexts = {}
+end
+
+local function open_binding()
+    local def, def_err = contract.get(CONTRACT_ID)
+    test.is_nil(def_err, "contract.get: " .. tostring(def_err))
+    test.not_nil(def)
+
+    local actor = security.new_actor(TEST_ACTOR_ID, { source = "session_service_test" })
+    local scope, scope_err = security.named_scope("wippy.session:test_group")
+    test.is_nil(scope_err, "security.named_scope: " .. tostring(scope_err))
+    test.not_nil(scope)
+
+    local instance, open_err = def
+        :with_actor(actor)
+        :with_scope(scope)
+        :open(BINDING_ID)
+    test.is_nil(open_err, "contract.open: " .. tostring(open_err))
+    test.not_nil(instance)
+    return instance
+end
+
+local function define_tests()
+    test.describe("session service", function()
+        before_all(function()
+            wait_for_boot.run()
+            cleanup()
+        end)
+
+        after_all(cleanup)
+
+        test.it("creates a session and owns the primary context", function()
+            local session_id, context_id = next_pair()
+
+            local result, err = service.ensure({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID,
+                primary_context_id = context_id,
+                title = "Service session",
+                kind = "channel",
+                meta = { source = "service_test" },
+                config = { model = "test-model" },
+                primary_context_data = { topic = "owned-context" }
+            })
+
+            test.is_nil(err, "ensure: " .. tostring(err))
+            test.not_nil(result)
+            test.is_true(result.created)
+            test.is_false(result.recovered)
+            test.eq(result.primary_context_id, context_id)
+            test.eq(result.session.session_id, session_id)
+            test.eq(result.session.status, consts.STATUS.IDLE)
+            test.eq(result.session.kind, "channel")
+            test.eq(result.session.meta.source, "service_test")
+
+            local context_row, context_err = context_repo.get(context_id)
+            test.is_nil(context_err, "context get: " .. tostring(context_err))
+            test.eq(context_row.type, consts.CONTEXT_TYPES.SESSION)
+
+            local decoded, decode_err = json.decode(context_row.data)
+            test.is_nil(decode_err, "context decode: " .. tostring(decode_err))
+            test.eq(decoded.topic, "owned-context")
+        end)
+
+        test.it("rehydrates an existing running session and resets it to idle", function()
+            local session_id, context_id = next_pair()
+            local created, create_err = service.ensure({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID,
+                primary_context_id = context_id
+            })
+            test.is_nil(create_err, "initial ensure: " .. tostring(create_err))
+            test.is_true(created.created)
+
+            local updated, update_err = service.update({
+                session_id = session_id,
+                updates = { status = consts.STATUS.RUNNING }
+            })
+            test.is_nil(update_err, "status update: " .. tostring(update_err))
+            test.eq(updated.status, consts.STATUS.RUNNING)
+
+            local result, err = service.ensure({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID,
+                primary_context_id = uuid.v7()
+            })
+
+            test.is_nil(err, "rehydrate ensure: " .. tostring(err))
+            test.is_false(result.created)
+            test.is_true(result.recovered)
+            test.eq(result.primary_context_id, context_id)
+            test.eq(result.session.status, consts.STATUS.IDLE)
+
+            local row, get_err = session_repo.get(session_id, TEST_ACTOR_ID)
+            test.is_nil(get_err, "session get: " .. tostring(get_err))
+            test.eq(row.status, consts.STATUS.IDLE)
+        end)
+
+        test.it("can preserve running status when reset_status is disabled", function()
+            local session_id, context_id = next_pair()
+            local created, create_err = service.ensure({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID,
+                primary_context_id = context_id
+            })
+            test.is_nil(create_err, "initial ensure: " .. tostring(create_err))
+            test.is_true(created.created)
+
+            local _, update_err = service.update({
+                session_id = session_id,
+                updates = { status = consts.STATUS.RUNNING }
+            })
+            test.is_nil(update_err, "status update: " .. tostring(update_err))
+
+            local result, err = service.ensure({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID,
+                reset_status = false
+            })
+
+            test.is_nil(err, "ensure reset disabled: " .. tostring(err))
+            test.is_false(result.created)
+            test.eq(result.session.status, consts.STATUS.RUNNING)
+        end)
+
+        test.it("deletes the session and its service-owned primary context", function()
+            local session_id, context_id = next_pair()
+            local created, create_err = service.ensure({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID,
+                primary_context_id = context_id
+            })
+            test.is_nil(create_err, "initial ensure: " .. tostring(create_err))
+            test.is_true(created.created)
+
+            local deleted, delete_err = service.delete({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID
+            })
+            test.is_nil(delete_err, "delete: " .. tostring(delete_err))
+            test.is_true(deleted.deleted)
+            test.is_true(deleted.primary_context_deleted)
+
+            local missing_session, session_err = service.get({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID
+            })
+            test.is_nil(missing_session)
+            test.contains(tostring(session_err), "Session not found")
+
+            local missing_context, context_err = context_repo.get(context_id)
+            test.is_nil(missing_context)
+            test.contains(tostring(context_err), "Context not found")
+        end)
+
+        test.it("routes service methods through the contract binding", function()
+            local session_id, context_id = next_pair()
+            local binding = open_binding()
+
+            local result, err = binding:ensure({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID,
+                primary_context_id = context_id,
+                title = "Contract session"
+            })
+            test.is_nil(err, "binding ensure: " .. tostring(err))
+            test.is_true(result.created)
+
+            local update, update_err = binding:update({
+                session_id = session_id,
+                updates = { title = "Updated by binding", status = consts.STATUS.RUNNING }
+            })
+            test.is_nil(update_err, "binding update: " .. tostring(update_err))
+            test.eq(update.title, "Updated by binding")
+
+            local row, get_err = binding:get({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID
+            })
+            test.is_nil(get_err, "binding get: " .. tostring(get_err))
+            test.eq(row.title, "Updated by binding")
+            test.eq(row.status, consts.STATUS.RUNNING)
+
+            local deleted, delete_err = binding:delete({
+                session_id = session_id,
+                user_id = TEST_ACTOR_ID
+            })
+            test.is_nil(delete_err, "binding delete: " .. tostring(delete_err))
+            test.is_true(deleted.deleted)
+        end)
+
+        test.it("returns validation errors before touching storage", function()
+            local result, err = service.ensure({ session_id = uuid.v7() })
+            test.is_nil(result)
+            test.contains(tostring(err), "user_id is required")
+
+            result, err = service.ensure({
+                session_id = uuid.v7(),
+                user_id = TEST_ACTOR_ID,
+                primary_context_data = 42
+            })
+            test.is_nil(result)
+            test.contains(tostring(err), "primary_context_data must be a string or table")
+        end)
+    end)
+end
+
+return test.run_cases(define_tests)

--- a/src/update_session_service.lua
+++ b/src/update_session_service.lua
@@ -1,0 +1,9 @@
+local service = require("service")
+
+local M = {}
+
+function M.handle(args)
+    return service.update(args)
+end
+
+return M

--- a/test/wippy.lock
+++ b/test/wippy.lock
@@ -27,5 +27,7 @@ modules:
       version: 0.5.1
       hash: ecb42a47c40415a2a3706071de488e21bc056a49d60ce7c3fa4e176fcefd16c1
 replacements:
+    - from: wippy/agent
+      to: ../../framework/src/agent/src
     - from: wippy/session
       to: ../src


### PR DESCRIPTION
Fixes session startup when older or minimally-created session rows have no config table.\n\nChanges:\n- normalize missing session_data.config to an empty table during session load\n- make live ctx.config reads tolerate nil during agent/model transition handling\n- add regression coverage for missing config startup and handler paths\n\nValidation:\n- make test: 115 passed\n- make lint: passed with existing fixpoint warning in wippy.session.process:message_handlers