### PR TITLE
feat(api): actor-scoped artifact catalog, plus artifact creation and metadata fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ placement with an `inline` render mode puts the content in its own message; a
 `standalone` render mode with an `inline` placement gives a chip embedded in the
 agent's reply.
 
+Placement must not be mapped onto `type`. Returning `meta.display_type` as
+`type` for every kind was tried and reverted: it collapses the two settings into
+one, so a `standalone` placement can no longer carry inline content — the
+combination the reference tools produce by default. An author who wants a chip
+asks for the render mode directly (`type = "standalone"`) rather than getting it
+as a side effect of where the artifact is delivered.
+
 ### Content modes
 
 Exactly one applies. `title` is always required.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,140 @@
 
 </div>
 
+## Artifacts
+
+An artifact is generated content that outlives the message that produced it. A
+tool returns `_control.artifacts`, this module persists it, writes the messages
+that reference it, and serves it over HTTP.
+
+### Render mode and placement
+
+An artifact carries two independent settings.
+
+| Setting | Field on `_control.artifacts[]` | Stored as |
+|---|---|---|
+| Render mode | `type` | the `kind` column |
+| Placement | `display_type` | `meta.display_type` |
+
+**Render mode** determines how a client draws the artifact. It is returned as
+`type` by `GET /artifact/{id}`.
+
+| `type` | Drawn as |
+|---|---|
+| `inline` (default) | the content itself, in the message |
+| `standalone` | a chip the reader clicks to open the artifact |
+| `inline-interactive` | the artifact in a sandboxed, proxy-enabled frame |
+| `view_ref` | a server-rendered page reference; requires `page_id` |
+
+Values are stored verbatim and are not validated. A value outside this set
+matches no renderer branch, and the artifact renders as nothing.
+
+**Placement** determines which messages this module writes, and therefore how
+the artifact reaches the thread.
+
+| `display_type` | Messages written | How it reaches the thread |
+|---|---|---|
+| `standalone` | `type="artifact"` with `metadata.artifact_id`, plus `system` `artifact_created` | the client renders the artifact message |
+| `inline` | a `developer` message carrying an embed instruction, plus `system` | the agent pastes `<artifact id="…"/>` into its reply |
+
+The reference tools derive placement from `instructions`: `true` → `inline`,
+otherwise `standalone`. The standalone artifact message is written only when
+`instructions` is exactly `false`; `nil` does not qualify.
+
+The two settings are independent — any combination is valid. A `standalone`
+placement with an `inline` render mode puts the content in its own message; a
+`standalone` render mode with an `inline` placement gives a chip embedded in the
+agent's reply.
+
+### Content modes
+
+Exactly one applies. `title` is always required.
+
+| Mode | Fields | Stored `content` | Default `content_type` |
+|---|---|---|---|
+| Text | `content`, optional `content_type` | the string verbatim | `text/markdown` |
+| Component tag | `content` = a `wippy-component-tag-1.0` package | JSON | `application/json` |
+| Component / page package | `content` = a `wippy-component-1.0` package | JSON | `application/json` |
+| Page reference | `page_id`, optional `params` | `params` as JSON | `text/html` |
+
+A page reference also requires `type: "view_ref"`. Its content endpoint renders
+the page server-side rather than returning stored bytes.
+
+### Control payload
+
+```lua
+return {
+  success = true,
+  _control = {
+    artifacts = {
+      {
+        title        = "Q3 summary",   -- required
+        content      = "# Q3 …",       -- one content mode
+        content_type = "text/markdown",
+        type         = "standalone",   -- render mode; omitted ⇒ "inline"
+        display_type = "standalone",   -- placement
+        instructions = false,
+        preview      = "",             -- shown before the artifact loads
+        description  = nil,
+        icon         = nil,
+        status       = nil,            -- omitted ⇒ "idle"
+      },
+    },
+  },
+}
+```
+
+`_control.artifacts` is a list; one tool call may produce several artifacts. A
+failing tool returns no `_control`.
+
+### HTTP API
+
+`GET /artifact/{id}` returns metadata for one artifact.
+
+| Field | Source |
+|---|---|
+| `uuid` | `artifact_id` |
+| `type` | the `kind` column; for `view_ref`, `meta.display_type` |
+| `kind` | the `kind` column |
+| `display_type` | `meta.display_type` |
+| `title`, `created_at`, `updated_at` | columns |
+| `content_type`, `description`, `icon`, `status` | from `meta` |
+| `page_id`, `is_view_reference`, `params` | `view_ref` only |
+| `content_version` | constant `1`; see limitations |
+
+`GET /artifact/{id}/content` returns raw bytes with `Content-Type` from
+`meta.content_type`, or `text/plain` when absent. A `view_ref` is rendered
+server-side.
+
+`GET /artifacts?session_id=&limit=&cursor=` returns an actor-scoped catalog,
+metadata only. Pagination is keyset over `(created_at DESC, artifact_id DESC)`.
+Cursors are opaque (`v1:<uuid>`) and resolved within the caller's own scope, so a
+cursor naming an inaccessible row is rejected. Rows carry `kind` and
+`display_type`; they do not carry `type`, so that one field name does not mean
+different things on two endpoints.
+
+### Realtime
+
+| Event | Topic | Payload |
+|---|---|---|
+| standalone artifact message stored | `session:<id>:message:<message_id>` | `{ type: "artifact", message_id, artifact_id }` |
+| any artifact created | `session:<id>` | `{ type: "update", artifact_added, session_id }` |
+
+Only `session:`-prefixed topics are relayed to clients.
+
+### Limitations
+
+- `kind` is stored verbatim from `type` with no enum check.
+- Updating an artifact replaces `meta` wholesale. The update path supplies only
+  `content_type`, `description`, `icon` and `status`, so `display_type`,
+  `page_id` and `preview` do not survive an update.
+- Supplying both `title` and `content` matches the create path first, so an
+  update shaped that way produces a second artifact with a new id.
+- `content_version` is constant, so a client caching on it will not refetch
+  updated content. Use `updated_at`.
+- A delegated tool call produces no artifact; the control payload is ignored.
+- SQLite does not cascade artifact deletion with its session. Orphaned rows
+  remain listable, and fetching one returns HTTP 500.
 
 [wippy-documentation]: https://docs.wippy.ai
 [releases-page]: https://github.com/wippyai/module-session/releases

--- a/src/_index.yaml
+++ b/src/_index.yaml
@@ -31,6 +31,10 @@ entries:
         path: .meta.router
       - entry: wippy.session.api:get_session.endpoint
         path: .meta.router
+      - entry: wippy.session.api:list_artifacts
+        path: .meta.router
+      - entry: wippy.session.api:list_artifacts.endpoint
+        path: .meta.router
       - entry: wippy.session.api:list_sessions
         path: .meta.router
       - entry: wippy.session.api:list_sessions.endpoint

--- a/src/api/_index.yaml
+++ b/src/api/_index.yaml
@@ -112,6 +112,32 @@ entries:
     func: get_session
     path: /sessions/get
 
+  # wippy.session.api:list_artifacts
+  - name: list_artifacts
+    kind: function.lua
+    meta:
+      comment: Lists metadata-only artifacts owned by the authenticated actor
+      router: app:api
+    source: file://list_artifacts.lua
+    modules:
+      - http
+      - security
+    imports:
+      artifact_repo: wippy.session.persist:artifact_repo
+    method: handler
+    pool:
+      size: 4
+
+  # wippy.session.api:list_artifacts.endpoint
+  - name: list_artifacts.endpoint
+    kind: http.endpoint
+    meta:
+      comment: Actor-scoped artifact catalog with optional session filtering and cursor pagination
+      router: app:api
+    method: GET
+    func: list_artifacts
+    path: /artifacts
+
   # wippy.session.api:list_sessions
   - name: list_sessions
     kind: function.lua

--- a/src/api/get_artifact.lua
+++ b/src/api/get_artifact.lua
@@ -134,6 +134,14 @@ local function handler()
         response.icon = artifact.meta.icon
         response.status = artifact.meta.status
         response.display_type = artifact.meta.display_type
+        -- `type` is the field artifact renderers branch on to choose between a
+        -- standalone card and an inline embed. Report the stored display mode for
+        -- every kind, not only view_ref: a Markdown/HTML artifact created with
+        -- display_type="standalone" is stored with kind="inline", so mapping only
+        -- view_ref left it advertising itself as inline and it rendered inline.
+        if artifact.meta.display_type then
+            response.type = artifact.meta.display_type
+        end
 
         -- Add page reference specific data if this is a view_ref artifact
         if artifact.kind == "view_ref" then

--- a/src/api/get_artifact.lua
+++ b/src/api/get_artifact.lua
@@ -134,14 +134,6 @@ local function handler()
         response.icon = artifact.meta.icon
         response.status = artifact.meta.status
         response.display_type = artifact.meta.display_type
-        -- `type` is the field artifact renderers branch on to choose between a
-        -- standalone card and an inline embed. Report the stored display mode for
-        -- every kind, not only view_ref: a Markdown/HTML artifact created with
-        -- display_type="standalone" is stored with kind="inline", so mapping only
-        -- view_ref left it advertising itself as inline and it rendered inline.
-        if artifact.meta.display_type then
-            response.type = artifact.meta.display_type
-        end
 
         -- Add page reference specific data if this is a view_ref artifact
         if artifact.kind == "view_ref" then

--- a/src/api/get_artifact.lua
+++ b/src/api/get_artifact.lua
@@ -7,6 +7,8 @@ local security = require("security")
 type ArtifactMetadataResponse = {
     uuid: string,
     type: string,
+    kind: string,
+    display_type: string?,
     title: string,
     created_at: string,
     updated_at: string,
@@ -118,6 +120,7 @@ local function handler()
     local response = {
         uuid = artifact.artifact_id,
         type = artifact.kind,
+        kind = artifact.kind,
         title = artifact.title,
         created_at = artifact.created_at,
         updated_at = artifact.updated_at,
@@ -130,11 +133,17 @@ local function handler()
         response.description = artifact.meta.description
         response.icon = artifact.meta.icon
         response.status = artifact.meta.status
+        response.display_type = artifact.meta.display_type
 
         -- Add page reference specific data if this is a view_ref artifact
         if artifact.kind == "view_ref" then
             response.page_id = artifact.meta.page_id
             response.is_view_reference = true
+            response.display_type = artifact.meta.display_type or "standalone"
+            -- Legacy overload, deliberately retained: existing clients (the
+            -- <w-artifact> renderer among them) read the display mode from
+            -- `type` for view_ref artifacts. New clients should read
+            -- `display_type`, which carries the same value for every kind.
             response.type = artifact.meta.display_type or "standalone"
 
             -- Also get the params if this is a view_ref

--- a/src/api/list_artifacts.lua
+++ b/src/api/list_artifacts.lua
@@ -1,0 +1,119 @@
+local http = require("http")
+local security = require("security")
+local artifact_repo = require("artifact_repo")
+
+local function bad_request(res, message)
+    res:set_status(http.STATUS.BAD_REQUEST)
+    res:write_json({ success = false, error = message })
+end
+
+local function is_uuid(value)
+    if type(value) ~= "string" or #value ~= 36 then return false end
+    local a, b, c, d, e = value:match("^(%x+)%-(%x+)%-(%x+)%-(%x+)%-(%x+)$")
+    return a ~= nil and #a == 8 and #b == 4 and #c == 4 and #d == 4 and #e == 12
+end
+
+local function parse_cursor(raw)
+    if not raw or raw == "" then return nil, nil end
+    if #raw > 64 then return nil, "Invalid artifact cursor" end
+    local artifact_id = raw:match("^v1:(.+)$")
+    if not is_uuid(artifact_id) then return nil, "Invalid artifact cursor" end
+    return artifact_id, nil
+end
+
+local function public_artifact(row)
+    local meta = type(row.meta) == "table" and row.meta or {}
+    return {
+        uuid = row.artifact_id,
+        artifact_id = row.artifact_id,
+        session_id = row.session_id,
+        kind = row.kind,
+        title = row.title,
+        created_at = row.created_at,
+        updated_at = row.updated_at,
+        display_type = meta.display_type,
+        content_type = meta.content_type,
+        description = meta.description,
+        preview = meta.preview,
+        icon = meta.icon,
+        status = meta.status,
+    }
+end
+
+local function handler()
+    local res = http.response()
+    local req = http.request()
+    if not res or not req then return nil, "Failed to get HTTP context" end
+
+    local actor = security.actor()
+    if not actor then
+        res:set_status(http.STATUS.UNAUTHORIZED)
+        res:write_json({ success = false, error = "Authentication required" })
+        return
+    end
+
+    local raw_limit = req:query("limit")
+    local limit = 50
+    if raw_limit and raw_limit ~= "" then
+        if not raw_limit:match("^%d+$") then
+            bad_request(res, "Limit must be an integer from 1 to 100")
+            return
+        end
+        limit = tonumber(raw_limit)
+        if not limit or limit < 1 or limit > 100 then
+            bad_request(res, "Limit must be an integer from 1 to 100")
+            return
+        end
+    end
+
+    local session_id = req:query("session_id")
+    if session_id == "" then session_id = nil end
+    if session_id and #session_id > 128 then
+        bad_request(res, "Invalid session ID")
+        return
+    end
+
+    local cursor_artifact_id, cursor_err = parse_cursor(req:query("cursor"))
+    if cursor_err then
+        bad_request(res, cursor_err)
+        return
+    end
+
+    local result, err = artifact_repo.list_by_user(
+        actor:id(),
+        session_id,
+        limit,
+        cursor_artifact_id
+    )
+    if err then
+        if err == "Invalid artifact cursor" then
+            bad_request(res, err)
+            return
+        end
+        res:set_status(http.STATUS.INTERNAL_ERROR)
+        res:write_json({ success = false, error = err })
+        return
+    end
+
+    local artifacts = {}
+    for _, row in ipairs(result.artifacts or {}) do
+        artifacts[#artifacts + 1] = public_artifact(row)
+    end
+
+    local next_cursor = nil
+    if result.has_more and #result.artifacts > 0 then
+        local last = result.artifacts[#result.artifacts]
+        next_cursor = "v1:" .. tostring(last.artifact_id)
+    end
+
+    res:set_content_type(http.CONTENT.JSON)
+    res:set_status(http.STATUS.OK)
+    res:write_json({
+        success = true,
+        count = #artifacts,
+        artifacts = artifacts,
+        pagination = { has_more = result.has_more == true, next_cursor = next_cursor },
+    })
+end
+
+return { handler = handler }

--- a/src/persist/artifact_repo.lua
+++ b/src/persist/artifact_repo.lua
@@ -314,6 +314,86 @@ function artifact_repo.list_by_session(session_id, limit, offset)
     return artifacts
 end
 
+-- List metadata-only artifacts owned by a user. The optional session filter is
+-- applied inside the same actor-scoped query. Cursor pagination uses the stable
+-- (created_at, artifact_id) ordering so concurrent inserts cannot shift rows
+-- between pages. Cursors carry only an opaque artifact id; the timestamp is
+-- resolved inside the same actor/session scope instead of trusting client data.
+function artifact_repo.list_by_user(user_id, session_id, limit, cursor_artifact_id)
+    if not user_id or user_id == "" then
+        return nil, "User ID is required"
+    end
+
+    limit = limit or 50
+    if limit < 1 then limit = 1 end
+
+    local db, err = get_db()
+    if err then return nil, err end
+
+    local cursor_created_at = nil
+    if cursor_artifact_id then
+        local cursor_filters = {
+            sql.builder.expr("user_id = ?", user_id),
+            sql.builder.expr("artifact_id = ?", cursor_artifact_id),
+        }
+        if session_id and session_id ~= "" then
+            cursor_filters[#cursor_filters + 1] = sql.builder.expr("session_id = ?", session_id)
+        end
+        local cursor_query = sql.builder.select("created_at", "artifact_id")
+            :from("artifacts")
+            :where(sql.builder.and_(cursor_filters))
+            :limit(1)
+        local cursor_rows, cursor_err = cursor_query:run_with(db):query()
+        if cursor_err then
+            db:release()
+            return nil, "Failed to resolve artifact cursor: " .. cursor_err
+        end
+        if #cursor_rows == 0 then
+            db:release()
+            return nil, "Invalid artifact cursor"
+        end
+        cursor_created_at = cursor_rows[1].created_at
+    end
+
+    local filters = { sql.builder.expr("user_id = ?", user_id) }
+    if session_id and session_id ~= "" then
+        filters[#filters + 1] = sql.builder.expr("session_id = ?", session_id)
+    end
+    if cursor_created_at and cursor_artifact_id then
+        filters[#filters + 1] = sql.builder.expr(
+            "(created_at < ? OR (created_at = ? AND artifact_id < ?))",
+            cursor_created_at,
+            cursor_created_at,
+            cursor_artifact_id
+        )
+    end
+
+    local query = sql.builder.select(
+            "artifact_id", "session_id", "kind", "title", "meta", "created_at", "updated_at"
+        )
+        :from("artifacts")
+        :where(sql.builder.and_(filters))
+        :order_by("created_at DESC, artifact_id DESC")
+        :limit(limit + 1)
+
+    local artifacts, query_err = query:run_with(db):query()
+    db:release()
+    if query_err then return nil, "Failed to list user artifacts: " .. query_err end
+
+    local has_more = #artifacts > limit
+    if has_more then table.remove(artifacts) end
+    for _, artifact in ipairs(artifacts) do
+        if artifact.meta and artifact.meta ~= "" then
+            local decoded, decode_err = json.decode(artifact.meta :: string)
+            artifact.meta = decode_err and {} or decoded
+        elseif not artifact.meta then
+            artifact.meta = {}
+        end
+    end
+
+    return { artifacts = artifacts, has_more = has_more }
+end
+
 -- List artifacts by kind
 function artifact_repo.list_by_kind(session_id, kind, limit, offset)
     if not session_id or session_id == "" then

--- a/src/persist/artifact_repo_test.lua
+++ b/src/persist/artifact_repo_test.lua
@@ -303,6 +303,103 @@ local function define_tests()
             test.is_nil(result)
             test.contains(tostring(err), "Artifact ID is required")
         end)
+
+        it("should list a user's artifacts with session scoping and cursor pagination", function()
+            -- Self-contained fixtures: the shared artifacts are updated and deleted
+            -- by earlier cases, so the catalog assertions own their rows outright.
+            local owner_id = uuid.v7()
+            local other_owner_id = uuid.v7()
+            local session_a = uuid.v7()
+            local session_b = uuid.v7()
+            local first_id = uuid.v7()
+            local second_id = uuid.v7()
+            local third_id = uuid.v7()
+            local foreign_id = uuid.v7()
+
+            local db_resource, _ = consts.get_db_resource()
+            local db, db_err = sql.get(db_resource)
+            if db_err then
+                error("Failed to connect to database: " .. db_err)
+            end
+
+            insert_artifact(db, first_id, session_a, owner_id, "static", "Catalog One",
+                "first content", { content_type = "text/markdown", display_type = "standalone" })
+            insert_artifact(db, second_id, session_a, owner_id, "static", "Catalog Two",
+                "second content", { content_type = "text/html", display_type = "inline" })
+            insert_artifact(db, third_id, session_b, owner_id, "dynamic", "Catalog Three",
+                "third content", { content_type = "application/json" })
+            insert_artifact(db, foreign_id, session_a, other_owner_id, "static", "Not Yours",
+                "foreign content", nil)
+
+            -- Everything this actor owns, across sessions.
+            local page, err = artifact_repo.list_by_user(owner_id, nil, 50, nil)
+            test.is_nil(err)
+            test.not_nil(page)
+            assert(page)
+            test.eq(#page.artifacts, 3)
+            test.eq(page.has_more, false)
+
+            -- A row owned by another actor is never returned, even from a shared session.
+            local by_id = {}
+            for _, artifact in ipairs(page.artifacts) do
+                by_id[artifact.artifact_id] = artifact
+            end
+            test.is_nil(by_id[foreign_id])
+            test.not_nil(by_id[first_id])
+            test.not_nil(by_id[second_id])
+            test.not_nil(by_id[third_id])
+
+            -- Metadata only: content bytes never reach the catalog.
+            test.is_nil(by_id[first_id].content)
+            test.eq(by_id[first_id].title, "Catalog One")
+            test.eq(by_id[second_id].meta.display_type, "inline")
+            test.eq(by_id[second_id].meta.content_type, "text/html")
+
+            -- The optional session filter narrows the same actor-scoped query.
+            local scoped, scoped_err = artifact_repo.list_by_user(owner_id, session_b, 50, nil)
+            test.is_nil(scoped_err)
+            assert(scoped)
+            test.eq(#scoped.artifacts, 1)
+            test.eq(scoped.artifacts[1].artifact_id, third_id)
+
+            -- Keyset pagination walks every row exactly once, with no gaps.
+            local seen = {}
+            local seen_count = 0
+            local cursor = nil
+            local pages = 0
+            repeat
+                local chunk, chunk_err = artifact_repo.list_by_user(owner_id, nil, 1, cursor)
+                test.is_nil(chunk_err)
+                assert(chunk)
+                for _, artifact in ipairs(chunk.artifacts) do
+                    test.is_nil(seen[artifact.artifact_id])
+                    seen[artifact.artifact_id] = true
+                    seen_count = seen_count + 1
+                    cursor = artifact.artifact_id
+                end
+                pages = pages + 1
+            until not chunk.has_more or pages > 10
+            test.eq(seen_count, 3)
+            test.eq(pages, 3)
+
+            -- An unknown cursor is rejected rather than silently restarting page one.
+            local invalid, invalid_err = artifact_repo.list_by_user(owner_id, nil, 50, uuid.v7())
+            test.is_nil(invalid)
+            test.contains(tostring(invalid_err), "Invalid artifact cursor")
+
+            -- A cursor naming another actor's row is out of scope, so it is invalid too.
+            local stolen, stolen_err = artifact_repo.list_by_user(owner_id, nil, 50, foreign_id)
+            test.is_nil(stolen)
+            test.contains(tostring(stolen_err), "Invalid artifact cursor")
+
+            local missing, missing_err = artifact_repo.list_by_user("", nil, 50, nil)
+            test.is_nil(missing)
+            test.contains(tostring(missing_err), "User ID is required")
+
+            db:execute("DELETE FROM artifacts WHERE session_id = $1 OR session_id = $2",
+                { session_a, session_b })
+            db:release()
+        end)
     end)
 end
 

--- a/src/process/control_handlers.lua
+++ b/src/process/control_handlers.lua
@@ -137,6 +137,7 @@ function control_handlers.control_artifacts(ctx, op)
                     {
                         content_type = artifact_data.content_type or consts.CONTENT_TYPES.HTML,
                         description = artifact_data.description,
+                        preview = artifact_data.preview,
                         icon = artifact_data.icon,
                         status = artifact_data.status or consts.ARTIFACT_STATUS.IDLE,
                         page_id = artifact_data.page_id,
@@ -179,6 +180,7 @@ function control_handlers.control_artifacts(ctx, op)
                     {
                         content_type = artifact_data.content_type or consts.CONTENT_TYPES.MARKDOWN,
                         description = artifact_data.description,
+                        preview = artifact_data.preview,
                         icon = artifact_data.icon,
                         status = artifact_data.status or consts.ARTIFACT_STATUS.IDLE,
                         display_type = artifact_data.display_type or consts.ARTIFACT_DISPLAY.INLINE
@@ -226,7 +228,14 @@ function control_handlers.control_artifacts(ctx, op)
                 -- reply (see the instructions block above). Emitting an artifact
                 -- message here for the inline case too would render it TWICE.
                 if artifact_data.instructions == false then
-                    ctx.writer:add_message(consts.MSG_TYPE.ARTIFACT, artifact_data.title, {
+                    local message_id, message_err = ctx.writer:add_message(consts.MSG_TYPE.ARTIFACT, artifact_data.title, {
+                        artifact_id = artifact_id
+                    })
+                    if message_err then
+                        return nil, "Failed to store standalone artifact message: " .. message_err
+                    end
+                    ctx.upstream:send_message_update(message_id, "artifact", {
+                        message_id = message_id,
                         artifact_id = artifact_id
                     })
                 end


### PR DESCRIPTION
Session-side support for a managed artifact workspace: an actor-scoped way to
enumerate artifacts, plus fixes on the creation and read paths found while
building against this module.

Three independent commits — each stands alone and can be dropped without
affecting the others. **No existing response field changes value.** See
*Backward compatibility* below for how that was verified.

## 1. `feat(api)` — actor-scoped artifact catalog

`GET /artifact/{id}` can fetch one artifact, but nothing enumerates what a user
owns. Any artifact inventory therefore has to be reconstructed by walking chat
messages, which cannot survive a reload or a reconnect and cannot page.

```
GET /api/v1/artifacts?session_id=<optional>&limit=50&cursor=<optional>
```

```json
{
  "success": true,
  "count": 2,
  "artifacts": [
    {
      "uuid": "…", "artifact_id": "…", "session_id": "…",
      "kind": "inline", "title": "Q3 summary",
      "display_type": "standalone", "content_type": "text/markdown",
      "description": null, "preview": "…", "icon": null, "status": "idle",
      "created_at": "…", "updated_at": "…"
    }
  ],
  "pagination": { "has_more": true, "next_cursor": "v1:0198f2…" }
}
```

Design points worth reviewing:

- **Scope comes from the server.** `security.actor():id()` is the only source of
  the owner filter; there is no `user_id` query parameter to forge. The optional
  `session_id` narrows *within* that same query rather than filtering afterwards.
- **Keyset, not `OFFSET`.** Ordering is `(created_at DESC, artifact_id DESC)`,
  stable under concurrent inserts — `LIMIT/OFFSET` would duplicate or skip rows
  as new artifacts land mid-pagination. `limit + 1` is fetched to derive
  `has_more` without a second `COUNT`.
- **Cursors are opaque and re-validated.** A cursor is `v1:<uuid>` carrying only
  an artifact id. Its `created_at` is resolved inside the caller's own
  actor/session scope, so a cursor naming a row the caller cannot see is
  rejected rather than resolving to a position in someone else's list. No
  client-supplied timestamp is trusted.
- **Metadata only.** The select list omits `content`, so listing never reads
  artifact bodies. Content is fetched only once a client selects one.
- `limit` is validated to 1–100; `cursor` is length- and shape-checked before it
  reaches the repository.
- **No `type` field.** Rows carry `kind` (storage kind) and `display_type`
  (display mode) as two distinct fields. `type` is deliberately absent: on
  `GET /artifact/{id}` that name carries a legacy overload (see §3), and reusing
  it here would make one field name mean different things on two endpoints for
  the same resource.

Tests are a self-contained case in `artifact_repo_test` (own session/user
fixtures, cleaned up in-test, so it neither depends on nor disturbs the shared
fixtures the update/delete cases mutate). It covers cross-actor isolation, the
session filter, metadata-only rows, a full keyset walk asserting no gaps or
duplicates, and rejection of both unknown and out-of-scope cursors.

## 2. `fix(artifacts)` — creation path

Three separate problems in `control_handlers.control_artifacts`:

- **`preview` was dropped.** It arrives in the `_control.artifacts` payload and
  is the line a client shows before an artifact loads, but it was never passed
  to `create_artifact`, so it never reached artifact meta and no reader could
  return it. Now passed through on both the view_ref and inline branches.
- **The standalone message was never announced.** It was written, but without a
  `send_message_update` a connected client only sees the card after a reload —
  which reads to the user as the artifact having been lost. This is the
  follow-on to #22: that PR made the message exist, this makes it arrive.
- **`add_message`'s error was discarded.** A failed write left a persisted
  artifact with no message referencing it, and the handler still reported
  success. Now propagated.

The inline path is untouched and still renders via the embed token.

## 3. `fix(api)` — `kind` and `display_type` as distinct fields

`GET /artifact/{id}` sets `type = artifact.kind`, then for `view_ref` artifacts
overwrites that same field with the display mode. One field carries two
unrelated vocabularies (`inline`/`view_ref` vs `standalone`/`inline`), so a
caller cannot tell which it was handed without already knowing the kind it was
trying to determine.

This adds `kind` (always the storage kind) and `display_type` (always the
display mode, for every artifact rather than only `view_ref`), matching the
names the catalog returns so detail and list responses describe an artifact the
same way.

**Purely additive — `type` is untouched.** The overload is deliberately retained
and commented in place. An earlier revision of this branch "cleaned it up" by
making `type` always report the kind; that would have broken the `<w-artifact>`
renderer, which branches on
`artifact.type === 'standalone' | 'inline' | 'inline-interactive'`
(`w-artifact.vue`, `w-artifact-block.vue`, `w-artifact-content.vue`) against a
response the Web Host consumes verbatim with no field mapping
(`make-artifact-api.ts` → `getMeta`). For `view_ref` artifacts — the ones where
those checks currently resolve — every branch would have gone false and the
artifact would have rendered as nothing. Reverted; new clients should read
`display_type`.

## Backward compatibility

Checked against the Web Host sources rather than assumed. The only consumer of
these fields branches on `type`; every value it can observe is unchanged.

Verified at runtime against a local build with this branch's session module
loaded, by seeding artifacts of each kind and display mode and reading the
detail endpoint back:

| artifact | `type` (legacy) | `kind` (new) | `display_type` (new) |
|---|---|---|---|
| `view_ref`, display `standalone` | `standalone` ✅ unchanged | `view_ref` | `standalone` |
| `view_ref`, display `inline` | `inline` ✅ unchanged | `view_ref` | `inline` |
| `inline` | `inline` ✅ unchanged | `inline` | `standalone` |

`is_view_reference`, `page_id` and `params` are also unchanged.

Browser verification (Playwright, HTTP cache disabled):

- Artifact gallery lists all artifacts from `GET /api/v1/artifacts` and renders
  a live `<w-artifact>` preview per card; the `display_type` value drives the
  "Standalone" label.
- Selecting one opens it beside chat and `<w-artifact>` renders it (496×873,
  upgraded, correct content), with chat still mounted.
- 22/22 artifact API requests returned `200`; zero console errors or warnings.

## Verification

- `wippy lint` — 144 entries checked. The 3 reported errors are all in
  `process:plugin_test`, which is not in this diff; every file changed here
  type-checks clean, including the new registry entries.
- Runtime behaviour of the catalog, `list_by_user`, the `preview` passthrough
  and `send_message_update` exercised in a browser as described above.
- `make test` **could not be run in my environment.** The harness resolves
  `wippy/agent` through a sibling `../../framework/src/agent/src` checkout, and
  against current `framework` master it aborts with
  `failed to save new version: invalid dependency resolution`. This reproduces
  identically on unmodified `master`, and still reproduces with the replacement
  dropped so `wippy/agent@0.4.8` resolves from the hub — so it is environmental
  and predates this branch, but it does mean **the new test case has not been
  executed.** Please run it before merging, or tell me the framework revision
  the harness expects and I will run it and report back.

## Context

Server half of Kickside EE2-2344 (managed artifact workspace: session and global
artifact inventories, selection, side-by-side preview). The client consumes
`GET /artifacts` for both inventories and reads `display_type` to separate
standalone from inline artifacts. Nothing here is Kickside-specific — no product
behaviour or naming is imported into this module.
